### PR TITLE
Opt-in into using channel's target agent version

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenity-star/sdk",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "The Serenity Star JavaScript SDK provides a convenient way to interact with the Serenity Star API, enabling you to build custom applications.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/sdk/readme.md
+++ b/packages/sdk/readme.md
@@ -12,6 +12,7 @@ The Serenity Star JS/TS SDK provides a comprehensive interface for interacting w
 - [Assistants / Copilots](#assistants--copilots)
   - [Start a new conversation with an Agent](#start-a-new-conversation-with-an-agent)
   - [Get conversation information](#get-conversation-information)
+  - [Use channel-pinned agent version](#use-channel-pinned-agent-version)
   - [Get conversation by id](#get-conversation-by-id)
   - [Sending messages within a conversation](#sending-messages-within-a-conversation)
     - [Stream message with SSE](#stream-message-with-sse)
@@ -113,6 +114,31 @@ console.log(
   agentInfoAdvanced.agent.version, // 2
 );
 ```
+
+## Use channel-pinned agent version
+
+By default, when no `agentVersion` is specified, the SDK executes the **latest** version of the agent. If your application uses channels that pin a specific agent version, you can opt in to that behavior with `useChannelVersion`:
+
+```tsx
+import SerenityClient from '@serenity-star/sdk';
+
+const client = new SerenityClient({
+  apiKey: '<SERENITY_API_KEY>',
+});
+
+// Opt in to using the version defined in the channel configuration
+const conversation = await client.agents.assistants.createConversation("chef-assistant", {
+  channel: "my-channel",
+  useChannelVersion: true,
+});
+
+// The conversation now targets the agent version pinned by the channel.
+// If the channel pins version 3, all messages will execute against version 3.
+const response = await conversation.sendMessage("Hello!");
+console.log(response.content);
+```
+
+> **Note:** An explicit `agentVersion` always takes priority over the channel's target version. When `useChannelVersion` is `false` (the default), the channel metadata is still available in `conversation.info` but does not affect which agent version is executed.
 
 ## Get conversation by id
 

--- a/packages/sdk/src/scopes/conversational/Conversation/index.ts
+++ b/packages/sdk/src/scopes/conversational/Conversation/index.ts
@@ -33,6 +33,7 @@ export class Conversation extends EventEmitter<SSEStreamEvents> {
   private userIdentifier?: string;
   private agentVersion?: number;
   private channel?: string;
+  private useChannelVersion: boolean;
   private inputParameters?: { [key: string]: any };
   public conversationId?: string;
   public info: ConversationInfoResult | null = null;
@@ -69,6 +70,7 @@ export class Conversation extends EventEmitter<SSEStreamEvents> {
     this.agentVersion = options?.agentVersion;
     this.userIdentifier = options?.userIdentifier;
     this.channel = options?.channel;
+    this.useChannelVersion = options?.useChannelVersion ?? false;
     this.inputParameters = options?.inputParameters;
   }
 
@@ -228,9 +230,26 @@ export class Conversation extends EventEmitter<SSEStreamEvents> {
   }
 
   async getInfo(): Promise<ConversationInfoResult> {
+    const info = await this.#fetchInfo(this.#getAgentVersion());
+
+    // If the consumer opted in to channel version pinning and no explicit
+    // agentVersion was provided, re-fetch info for the channel's target version
+    // so the returned info matches the version that will be executed.
+    const targetVersion = info.channel?.targetAgentVersion;
+    if (this.useChannelVersion && !this.agentVersion && targetVersion && targetVersion !== this.#getAgentVersion()) {
+      const versionedInfo = await this.#fetchInfo(targetVersion);
+      this.info = versionedInfo;
+      return this.info;
+    }
+
+    this.info = info;
+    return this.info;
+  }
+
+  async #fetchInfo(agentVersion?: number): Promise<ConversationInfoResult> {
     let url = `${this.baseUrl}/v2/agent/${this.agentCode}`;
-    if (this.agentVersion) {
-      url += `/${this.agentVersion}`;
+    if (agentVersion) {
+      url += `/${agentVersion}`;
     }
     url += "/conversation/info";
 
@@ -267,11 +286,9 @@ export class Conversation extends EventEmitter<SSEStreamEvents> {
       const error = await InternalErrorHelper.process(response, "Failed to get conversation initial info");
       throw error;
     }
-    
+
     const data = await response.json();
-    
-    this.info = data as ConversationInfoResult;
-    return this.info;
+    return data as ConversationInfoResult;
   }
 
   /**
@@ -509,8 +526,19 @@ export class Conversation extends EventEmitter<SSEStreamEvents> {
   }
 
   #getExecuteUrl(): string {
-    const version = this.agentVersion ? `/${this.agentVersion}` : "";
+    const agentVersion = this.#getAgentVersion();
+    const version = agentVersion ? `/${agentVersion}` : "";
     return `${this.baseUrl}/v2/agent/${this.agentCode}/execute${version}`;
+  }
+
+  #getAgentVersion() {
+    if(this.agentVersion) {
+      return this.agentVersion;
+    }
+    if(this.useChannelVersion && this.info?.channel?.targetAgentVersion) {
+      return this.info.channel.targetAgentVersion;
+    }
+    return undefined;
   }
 
   #createExecuteBody(options: CreateExecuteBodyOptions): ExecuteBodyParams {

--- a/packages/sdk/src/scopes/conversational/Conversation/types.ts
+++ b/packages/sdk/src/scopes/conversational/Conversation/types.ts
@@ -50,6 +50,7 @@ export type ChatWidgetRes = {
   locale: LocaleRes;
   theme: ThemeRes;
   enableFeedbackRecollection: boolean;
+  targetAgentVersion?: number;
 }
 
 type EngagementMessageRes = {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -33,6 +33,13 @@ export type AgentSetupOptions = {
    */
   channel?: string;
   /**
+   * When true, the SDK will use the agent version defined in the channel configuration
+   * (if available) instead of defaulting to the latest version.
+   * Only takes effect when a `channel` is provided and no explicit `agentVersion` is set.
+   * @default false
+   */
+  useChannelVersion?: boolean;
+  /**
    * Optional key-value pairs of input parameters specific to the agent.
    */
   inputParameters?: { [key: string]: any }


### PR DESCRIPTION
## Problem

When `agentVersion` was not provided while creating a new conversation, the sdk automatically fell back to the agent's latest version for **every** SDK consumer. But some clients like the chat widget needs a mechanism to opt-in into targeting a specific agent version defined within the channel.

## Solution

Added a new `useChannelVersion` option (default `false`) to `AgentSetupOptions`. When enabled:

- `getInfo()` re-fetches agent info for the channel's `targetAgentVersion`
- `#getAgentVersion()` falls back to the channel's pinned version
- `#getExecuteUrl()` uses the resolved version

When disabled (default), channel metadata is still available in `conversation.info` but does not affect which agent version is executed — the SDK defaults to latest.

## Changes

- **`src/types.ts`** — Added `useChannelVersion?: boolean` to `AgentSetupOptions`
- **`src/scopes/conversational/Conversation/index.ts`** — Stored the flag, extracted `#fetchInfo()` for re-fetch logic, guarded version fallback behind the flag in `#getAgentVersion()` and `getInfo()`
- **`src/scopes/conversational/Conversation/types.ts`** — Added `targetAgentVersion` to `ChatWidgetRes`
- **`readme.md`** — Documented the new option with usage examples
- **package.json** — Bumped version to 2.4.3

## Backward compatibility

Fully backward-compatible. Default `false` preserves existing behavior for all current consumers. An explicit `agentVersion` always takes priority.