### PR TITLE
feat: Agent Client Credentials authentication mode

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenity-star/sdk",
-  "version": "2.4.4",
+  "version": "2.5.0",
   "description": "The Serenity Star JavaScript SDK provides a convenient way to interact with the Serenity Star API, enabling you to build custom applications.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/sdk/readme.md
+++ b/packages/sdk/readme.md
@@ -8,6 +8,10 @@ The Serenity Star JS/TS SDK provides a comprehensive interface for interacting w
 - [Serenity Star JS/TS SDK](#serenity-star-jsts-sdk)
   - [Table of Contents](#table-of-contents)
 - [Installation](#installation)
+- [Authentication Modes](#authentication-modes)
+  - [API Key (Full Access)](#api-key-full-access)
+  - [Agent Client Credentials (Token Provider)](#agent-client-credentials-token-provider)
+  - [Feature Comparison](#feature-comparison)
 - [Usage](#usage)
 - [Assistants / Copilots](#assistants--copilots)
   - [Start a new conversation with an Agent](#start-a-new-conversation-with-an-agent)
@@ -45,6 +49,81 @@ The Serenity Star JS/TS SDK provides a comprehensive interface for interacting w
 npm install @serenity-star/sdk
 ```
 
+# Authentication Modes
+
+The SDK supports two authentication modes that determine how the client is instantiated and which features are available.
+
+## API Key (Full Access)
+
+Use an API key when you want full access to all agents and services. API keys can have permission restrictions configured in Serenity\* Star.
+
+```tsx
+import SerenityClient from '@serenity-star/sdk';
+
+const client = new SerenityClient({
+  apiKey: '<SERENITY_API_KEY>',
+});
+
+// agentCode is passed to each operation
+const conversation = await client.agents.assistants.createConversation("chef-assistant");
+
+// All services are available
+const transcript = await client.services.audio.transcribe(audioFile, { modelId: '<MODEL_ID>' });
+```
+
+## Agent Client Credentials (Token Provider)
+
+Use Agent Client Credentials when you want the client scoped to a **single agent** and to obtain short-lived access tokens through a callback you provide. This mode does not expose long-lived credentials in your client code.
+
+> **Setup:** Agent Client Credentials are created per-agent in the **Agent Design Studio** inside Serenity\* Star. Each credential set includes a `ClientId`, `ClientSecret`, and `publicKey`.
+> - **`ClientId` and `ClientSecret`** must be kept server-side only. Your backend uses them to issue a short-lived client token.
+> - **`publicKey`** is safe to expose in your client-side code and is passed to the `SerenityClient` constructor.
+
+The `agentCode` is fixed at construction time and is **not passed** to individual method calls. The SDK manages the full token lifecycle (acquisition, proactive refresh, retry on 401) transparently.
+
+```tsx
+import SerenityClient from '@serenity-star/sdk';
+
+const client = new SerenityClient({
+  agentClientCredentials: {
+    agentCode: "chef-assistant",
+    publicKey: "<PUBLIC_KEY>",         // safe to expose client-side
+    tokenProvider: async ({ context }) => {
+      // Call your backend, which uses ClientId + ClientSecret to issue a token
+      const res = await fetch("/api/get-serenity-token", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          publicKey: context.publicKey,
+          agentCode: context.agentCode,
+        }),
+      });
+      return (await res.json()).token;
+    },
+  },
+});
+
+// agentCode is NOT passed — it was fixed at construction time
+const conversation = await client.agents.assistants.createConversation();
+```
+
+> **Note:** Your `tokenProvider` callback only needs to return a client token from your backend. The SDK handles the token exchange with the Serenity API automatically — calling the exchange endpoint, obtaining a short-lived access token, and refreshing it transparently.
+
+## Feature Comparison
+
+| Feature | API Key | Agent Client Credentials |
+|---|---|---|
+| `agents.assistants.createConversation(agentCode, options?)` | ✅ | ➡️ `createConversation(options?)` |
+| `agents.assistants.getInfoByCode(agentCode, options?)` | ✅ | ➡️ `getInfo(options?)` |
+| `agents.assistants.getConversationById(agentCode, id, options?)` | ✅ | ➡️ `getConversationById(id, options?)` |
+| `agents.assistants.createRealtimeSession(agentCode, options?)` | ✅ | ❌ Not available |
+| `agents.copilots.*` | ✅ Same as assistants | ➡️ Same scoping as assistants |
+| `agents.activities.execute(agentCode, options?)` | ✅ | ➡️ `execute(options?)` |
+| `agents.activities.create(agentCode, options?)` | ✅ | ➡️ `create(options?)` |
+| `agents.chatCompletions.*` | ✅ Same as activities | ➡️ Same scoping as activities |
+| `agents.proxies.*` | ✅ Same as activities | ➡️ Same scoping as activities |
+| `services.audio.transcribe(...)` | ✅ | ❌ Not available (`services` is undefined) |
+
 # Usage
 
 ```tsx
@@ -73,6 +152,13 @@ const client = new SerenityClient({
 // Create a new conversation with an assistant
 const conversation = await client.agents.assistants.createConversation("chef-assistant");
 ```
+
+> **Token Provider Auth:** Omit `agentCode` — it was fixed at construction time.
+> ```ts
+> const conversation = await client.agents.assistants.createConversation();
+> // or with options:
+> const conversation = await client.agents.assistants.createConversation({ channel: "web" });
+> ```
 
 ## Get conversation information
 
@@ -115,6 +201,13 @@ console.log(
 );
 ```
 
+> **Token Provider Auth:** Use `getInfo(options?)` instead of `getInfoByCode(agentCode, options?)`.
+> ```ts
+> const agentInfo = await client.agents.assistants.getInfo();
+> // with options:
+> const agentInfo = await client.agents.assistants.getInfo({ agentVersion: 2 });
+> ```
+
 ## Use channel-pinned agent version
 
 By default, when no `agentVersion` is specified, the SDK executes the **latest** version of the agent. If your application uses channels that pin a specific agent version, you can opt in to that behavior with `useChannelVersion`:
@@ -139,6 +232,14 @@ console.log(response.content);
 ```
 
 > **Note:** An explicit `agentVersion` always takes priority over the channel's target version. When `useChannelVersion` is `false` (the default), the channel metadata is still available in `conversation.info` but does not affect which agent version is executed.
+
+> **Token Provider Auth:** Same options, omit `agentCode`.
+> ```ts
+> const conversation = await client.agents.assistants.createConversation({
+>   channel: "my-channel",
+>   useChannelVersion: true,
+> });
+> ```
 
 ## Get conversation by id
 
@@ -167,6 +268,13 @@ console.log(
   conversationWithLogs.executorTaskLogs // Detailed task execution logs
 );
 ```
+
+> **Token Provider Auth:** Omit `agentCode`.
+> ```ts
+> const conversation = await client.agents.assistants.getConversationById("<conversation-id>");
+> // with options:
+> const conversationWithLogs = await client.agents.assistants.getConversationById("<conversation-id>", { showExecutorTaskLogs: true });
+> ```
 
 ## Sending messages within a conversation
 
@@ -262,6 +370,8 @@ session.unmuteMicrophone()
 // Stop the session
 session.stop();
 ```
+
+> **Token Provider Auth:** `createRealtimeSession` is not available with this auth mode. Realtime features require API Key authentication.
 
 ## Message Feedback
 
@@ -393,6 +503,13 @@ console.log(
 )
 ```
 
+> **Token Provider Auth:** Omit `agentCode`.
+> ```ts
+> const response = await client.agents.activities.execute();
+> // with options:
+> const response = await client.agents.activities.execute({ inputParameters: { targetLanguage: "russian", textToTranslate: "hello world" } });
+> ```
+
 ## Stream responses with SSE
 
 ```tsx
@@ -426,6 +543,11 @@ console.log(
 );
 ```
 
+> **Token Provider Auth:** Omit `agentCode` from `create()`.
+> ```ts
+> const activity = client.agents.activities.create({ inputParameters: { targetLanguage: "russian", textToTranslate: "hello world" } })
+> ```
+
 ---
 
 
@@ -455,6 +577,11 @@ console.log(
 );
 
 ```
+
+> **Token Provider Auth:** Omit `agentCode`.
+> ```ts
+> const response = await client.agents.proxies.execute({ model: "gpt-4o-mini-2024-07-18", messages: [{ role: "user", content: "What is artificial intelligence?" }] });
+> ```
 
 ## Stream responses with SSE
 
@@ -491,6 +618,11 @@ console.log(
 );
 
 ```
+
+> **Token Provider Auth:** Omit `agentCode` from `create()`.
+> ```ts
+> const proxy = client.agents.proxies.create({ model: "gpt-4o-mini-2024-07-18", messages: [{ role: "user", content: "What is artificial intelligence?" }] })
+> ```
 
 ## Proxy Execution Options
 
@@ -571,6 +703,11 @@ console.log(
 
 ```
 
+> **Token Provider Auth:** Omit `agentCode`.
+> ```ts
+> const response = await client.agents.chatCompletions.execute({ message: "Hello!!!" });
+> ```
+
 ## Stream responses with SSE
 
 ```tsx
@@ -606,6 +743,11 @@ console.log(
   response.completion_usage, // { completion_tokens: 200, prompt_tokens: 30, total_tokens: 230 }
 );
 ```
+
+> **Token Provider Auth:** Omit `agentCode` from `create()`.
+> ```ts
+> const chatCompletion = client.agents.chatCompletions.create({ message: "Hi! How can I eat healthier?" })
+> ```
 
 ---
 
@@ -874,3 +1016,5 @@ const conversation = await client.agents.assistants.createConversation("chef-ass
 const response = await conversation.sendMessage(result.transcript);
 console.log(response.content); // AI response based on the transcribed audio
 ```
+
+> **Token Provider Auth:** `client.services.audio` is not available with this auth mode. Audio transcription requires API Key authentication.

--- a/packages/sdk/src/SerenityClient.ts
+++ b/packages/sdk/src/SerenityClient.ts
@@ -2,6 +2,8 @@ import {
   AgentFactory,
   ConversationalAgentScope,
   SystemAgentScope,
+  ScopedConversationalAgentScope,
+  ScopedSystemAgentScope,
 } from "./factories/AgentFactory";
 import {
   ServiceFactory,
@@ -10,246 +12,116 @@ import {
 import { Activity } from "./scopes/system/Activity";
 import { ChatCompletion } from "./scopes/system/ChatCompletion";
 import { Proxy } from "./scopes/system/Proxy";
-import { SerenityClientOptions } from "./types";
+import { ApiKeyClientOptions, AgentClientCredentialsOptions, SerenityClientOptions } from "./types";
+import { createAuthProvider } from "./auth";
 
-export default class SerenityClient {
-  private apiKey: string;
+// ─── Full client shape (API Key) ───
+export type FullAgents = {
+  assistants: ConversationalAgentScope<"assistant">;
+  copilots: ConversationalAgentScope<"copilot">;
+  activities: SystemAgentScope<"activity", Activity>;
+  chatCompletions: SystemAgentScope<"chat-completion", ChatCompletion>;
+  proxies: SystemAgentScope<"proxy", Proxy>;
+};
+
+export type FullServices = {
+  audio: AudioServiceScope;
+};
+
+// ─── Scoped client shape (Agent Client Credentials) ───
+export type ScopedAgents = {
+  assistants: ScopedConversationalAgentScope<"assistant">;
+  copilots: ScopedConversationalAgentScope<"copilot">;
+  activities: ScopedSystemAgentScope<"activity", Activity>;
+  chatCompletions: ScopedSystemAgentScope<"chat-completion", ChatCompletion>;
+  proxies: ScopedSystemAgentScope<"proxy", Proxy>;
+};
+
+/** Full-access client returned when using API Key authentication */
+export class FullSerenityClient {
   private baseUrl = "https://api.serenitystar.ai/api";
 
   /**
    * Interact with the different agents available in Serenity Star.
    * You can choose between assistants, copilots, activities, chat completions and proxies.
    */
-  public readonly agents: {
-    /**
-     * Interact with Assistant agents available in Serenity Star.
-     * This allows you to create conversations and real-time sessions.
-     * 
-     * ## Start a new conversation and send a message:
-     * ```typescript
-     * // Regular text conversation
-     * const conversation = await client.agents.assistants.createConversation("translator-assistant");
-     * const response = await conversation.sendMessage("The sun was beginning to set...");
-     * console.log(response.content);
-     * 
-     * ```
-     * 
-     * ## Stream message with SSE
-     * ```typescript
-     * const conversation = await client.agents.assistants
-     *   .createConversation("translator-assistant")
-     *   .on("start", () => console.log("Started"))
-     *   .on("content", (chunk) => console.log(chunk))
-     *   .on("error", (error) => console.error(error));
-     * 
-     * await conversation.streamMessage("The sun was beginning to set...");
-     * 
-     * ```
-     * 
-     * ## Real-time voice conversation example:
-     * ```typescript
-     * const session = client.agents.assistants.createRealtimeSession("marketing-assistant")
-     *   .on("session.created", () => console.log("Session started"))
-     *   .on("speech.started", () => console.log("User started talking"))
-     *   .on("speech.stopped", () => console.log("User stopped talking"))
-     *   .on("response.done", (response) => console.log("Response:", response))
-     *   .on("session.stopped", () => console.log("Session stopped"));
-     * 
-     * await session.start();
-     * // Later: session.stop();
-     * ```
-     */
-    assistants: ConversationalAgentScope<"assistant">;
-
-    /**
-     * Interact with Copilot agents available in Serenity Star.
-     * Similar to assistants but allows you to interact with the UI through callbacks.
-     * 
-     * Text conversation example:
-     * ```typescript
-     * // Regular conversation
-     * const conversation = await client.agents.copilots.createConversation("app-copilot");
-     * const response = await conversation.sendMessage("How do I create a new support ticket?");
-     * console.log(response.content);
-     * 
-     * // Streaming conversation
-     * const conversation = await client.agents.copilots
-     *   .createConversation("app-copilot")
-     *   .on("start", () => console.log("Started"))
-     *   .on("content", (chunk) => console.log(chunk))
-     *   .on("error", (error) => console.error(error));
-     * 
-     * await conversation.streamMessage("How do I create a new support ticket?");
-     * ```
-     */
-    copilots: ConversationalAgentScope<"copilot">;
-
-    /**
-     * Interact with Activity agents available in Serenity Star.
-     * This allows you to execute activities.
-     * It supports streaming.
-     * Execute simple tasks based on the user input.
-     * 
-     * ## Regular activity execution:
-     * ```typescript
-     * const response = await client.agents.activities.execute("marketing-campaign")
-     * console.log(response.content);
-     * 
-     * // With parameters
-     * const response = await client.agents.activities.execute("cooking-activity", {
-     *   inputParameters: {
-     *     ingredientOne: "chicken",
-     *     ingredientTwo: "onion",
-     *     ingredientThree: "cream",
-     *   }
-     * });
-     * ```
-     * 
-     * ## Stream activity with SSE:
-     * ```typescript
-     * const activity = client.agents.activities
-     *   .create("marketing-campaign")
-     *   .on("start", () => console.log("Started"))
-     *   .on("content", (chunk) => console.log(chunk))
-     *   .on("error", (error) => console.error(error));
-     * 
-     * await activity.stream();
-     * ```
-     */
-    activities: SystemAgentScope<"activity", Activity>;
-
-    /**
-     * Interact with Chat Completion agents available in Serenity Star.
-     * This allows you to execute chat completions.
-     * It supports streaming.
-     * Chat completions allows you to fully control the conversation and generate completions.
-     * 
-     * ## Regular chat completion:
-     * ```typescript
-     * const response = await client.agents.chatCompletions.execute("Health-Coach", {
-     *   message: "Hello!"
-     * });
-     * console.log(response.content);
-     * ```
-     * 
-     * ## Stream chat completion with SSE:
-     * ```typescript
-     * const chatCompletion = client.agents.chatCompletions
-     *   .create("Health-Coach", {
-     *     message: "Hello!"
-     *   })
-     *   .on("start", () => console.log("Started"))
-     *   .on("content", (chunk) => console.log(chunk))
-     *   .on("error", (error) => console.error(error));
-     * 
-     * await chatCompletion.stream();
-     * ```
-     */
-    chatCompletions: SystemAgentScope<"chat-completion", ChatCompletion>;
-
-    /**
-     * Interact with Proxy agents available in Serenity Star.
-     * This allows you to execute proxies.
-     * It supports streaming.
-     * Proxy agents allows you to define a set of parameters dynamically for each request
-     * 
-     * ## Regular proxy execution:
-     * ```typescript
-     * const response = await client.agents.proxies.execute("proxy-agent", {
-     *   model: "gpt-4o-mini-2024-07-18",
-     *   messages: [
-     *     {
-     *       role: "system",
-     *       content: "You are a helpful assistant. Always use short and concise responses"
-     *     },
-     *     { role: "user", content: "What is artificial intelligence?" }
-     *   ],
-     *   temperature: 1,
-     *   max_tokens: 250
-     * });
-     * console.log(response.content);
-     * ```
-     * 
-     * ## Stream proxy with SSE:
-     * ```typescript
-     * const proxy = client.agents.proxies
-     *   .create("proxy-agent", {
-     *     model: "gpt-4o-mini-2024-07-18",
-     *     messages: [
-     *     {
-     *       role: "system",
-     *       content: "You are a helpful assistant. Always use short and concise responses"
-     *     },
-     *       { role: "user", content: "What is artificial intelligence?" }
-     *     ],
-     *     temperature: 1,
-     *     max_tokens: 250
-     *   })
-     *   .on("start", () => console.log("Started"))
-     *   .on("content", (chunk) => console.log(chunk))
-     *   .on("error", (error) => console.error(error));
-     * 
-     * await proxy.stream();
-     * ```
-     */
-    proxies: SystemAgentScope<"proxy", Proxy>;
-  };
+  public readonly agents: FullAgents;
 
   /**
    * Access various services provided by Serenity Star.
    * Services include audio transcription and other utility features.
    */
-  public readonly services: {
-    /**
-     * Audio-related services including transcription.
-     * 
-     * ## Transcribe an audio file:
-     * ```typescript
-     * const file = new File([audioBlob], "audio.mp3", { type: "audio/mpeg" });
-     * const result = await client.services.audio.transcribe(file, {
-     *   modelId: '[YOUR_MODEL_ID]',
-     *   prompt: 'This is a conversation about AI',
-     *   userIdentifier: 'user123'
-     * });
-     * 
-     * console.log('Transcript:', result.transcript);
-     * console.log('Duration:', result.metadata?.duration);
-     * console.log('Total tokens:', result.tokenUsage?.totalTokens);
-     * console.log('Cost:', result.cost?.total, result.cost?.currency);
-     * ```
-     */
-    audio: AudioServiceScope;
-  };
+  public readonly services: FullServices;
 
-  constructor(options: SerenityClientOptions) {
-    if (!options.apiKey) {
-      throw new Error("The API key is required");
-    }
-    this.apiKey = options.apiKey;
+  constructor(options: ApiKeyClientOptions) {
     this.baseUrl = options.baseUrl || this.baseUrl;
+    const authProvider = createAuthProvider(options);
 
     this.agents = {
-      assistants: AgentFactory.createAgent(
-        "assistant",
-        this.apiKey,
-        this.baseUrl
-      ),
-      copilots: AgentFactory.createAgent("copilot", this.apiKey, this.baseUrl),
-      activities: AgentFactory.createAgent(
-        "activity",
-        this.apiKey,
-        this.baseUrl
-      ),
-      chatCompletions: AgentFactory.createAgent(
-        "chat-completion",
-        this.apiKey,
-        this.baseUrl
-      ),
-      proxies: AgentFactory.createAgent("proxy", this.apiKey, this.baseUrl),
+      assistants: AgentFactory.createAgent("assistant", authProvider, this.baseUrl),
+      copilots: AgentFactory.createAgent("copilot", authProvider, this.baseUrl),
+      activities: AgentFactory.createAgent("activity", authProvider, this.baseUrl),
+      chatCompletions: AgentFactory.createAgent("chat-completion", authProvider, this.baseUrl),
+      proxies: AgentFactory.createAgent("proxy", authProvider, this.baseUrl),
     };
-
     this.services = {
-      audio: ServiceFactory.createService("audio", this.apiKey, this.baseUrl),
+      audio: ServiceFactory.createService("audio", authProvider, this.baseUrl),
     };
   }
 }
+
+/** Agent-scoped client returned when using Agent Client Credentials authentication */
+export class ScopedSerenityClient {
+  private baseUrl = "https://api.serenitystar.ai/api";
+
+  /**
+   * Interact with the agent scoped to this client.
+   * Operations do not require an agentCode parameter — it is baked in.
+   */
+  public readonly agents: ScopedAgents;
+
+  constructor(options: AgentClientCredentialsOptions) {
+    this.baseUrl = options.baseUrl || this.baseUrl;
+    const authProvider = createAuthProvider(options);
+    const agentCode = options.agentClientCredentials.agentCode;
+
+    this.agents = {
+      assistants: AgentFactory.createScopedAgent("assistant", agentCode, authProvider, this.baseUrl),
+      copilots: AgentFactory.createScopedAgent("copilot", agentCode, authProvider, this.baseUrl),
+      activities: AgentFactory.createScopedAgent("activity", agentCode, authProvider, this.baseUrl),
+      chatCompletions: AgentFactory.createScopedAgent("chat-completion", agentCode, authProvider, this.baseUrl),
+      proxies: AgentFactory.createScopedAgent("proxy", agentCode, authProvider, this.baseUrl),
+    };
+  }
+}
+
+/**
+ * Create a Serenity client. Returns a `FullSerenityClient` when using API Key auth,
+ * or a `ScopedSerenityClient` when using Agent Client Credentials.
+ *
+ * @example
+ * // API Key — full access
+ * const client = new SerenityClient({ apiKey: "sk_..." });
+ * client.agents.assistants.createConversation(agentCode, options);
+ * client.services.audio.transcribe(file);
+ *
+ * @example
+ * // Agent Client Credentials — scoped access
+ * const client = new SerenityClient({ agentClientCredentials: { agentCode, publicKey, tokenProvider } });
+ * client.agents.assistants.createConversation(options); // no agentCode needed
+ */
+function _SerenityClientFactory(options: SerenityClientOptions) {
+  if ("apiKey" in options && options.apiKey) {
+    return new FullSerenityClient(options as ApiKeyClientOptions);
+  }
+  return new ScopedSerenityClient(options as AgentClientCredentialsOptions);
+}
+
+// ─── Type-level overloads for `new SerenityClient(...)` ───
+export interface SerenityClientConstructor {
+  new (options: ApiKeyClientOptions): FullSerenityClient;
+  new (options: AgentClientCredentialsOptions): ScopedSerenityClient;
+}
+
+export const SerenityClient = _SerenityClientFactory as unknown as SerenityClientConstructor;
+export default SerenityClient;

--- a/packages/sdk/src/auth/ApiKeyAuthProvider.ts
+++ b/packages/sdk/src/auth/ApiKeyAuthProvider.ts
@@ -1,0 +1,17 @@
+import { AuthProvider } from "./AuthProvider";
+
+export class ApiKeyAuthProvider implements AuthProvider {
+  constructor(private readonly apiKey: string) {}
+
+  async getHeaders(): Promise<Record<string, string>> {
+    return { "X-API-KEY": this.apiKey };
+  }
+
+  async getWebSocketProtocols(): Promise<string[]> {
+    return ["X-API-KEY", this.apiKey];
+  }
+
+  async handleUnauthorized(): Promise<boolean> {
+    return false; // Static keys can't be refreshed
+  }
+}

--- a/packages/sdk/src/auth/AuthProvider.ts
+++ b/packages/sdk/src/auth/AuthProvider.ts
@@ -1,0 +1,13 @@
+export interface AuthProvider {
+  /** Returns the headers to attach to HTTP requests */
+  getHeaders(): Promise<Record<string, string>>;
+
+  /** Returns the WebSocket sub-protocols for authentication */
+  getWebSocketProtocols(): Promise<string[]>;
+
+  /**
+   * Handles a 401 Unauthorized response.
+   * Returns true if the token was refreshed and the request should be retried.
+   */
+  handleUnauthorized(response: Response): Promise<boolean>;
+}

--- a/packages/sdk/src/auth/TokenAuthProvider.ts
+++ b/packages/sdk/src/auth/TokenAuthProvider.ts
@@ -1,0 +1,96 @@
+import { AuthProvider } from "./AuthProvider";
+import { TokenProviderFn } from "../types";
+
+export class TokenAuthProvider implements AuthProvider {
+  private accessToken: string | null = null;
+  private tokenPromise: Promise<string> | null = null;
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(
+    private readonly publicKey: string,
+    private readonly tokenProvider: TokenProviderFn,
+    private readonly baseUrl: string,
+    private readonly agentCode: string
+  ) {}
+
+  async getHeaders(): Promise<Record<string, string>> {
+    const token = await this.ensureToken();
+    return { Authorization: `Bearer ${token}` };
+  }
+
+  async getWebSocketProtocols(): Promise<string[]> {
+    throw new Error(
+      "Token Provider auth does not support WebSocket connections (RealtimeSession). " +
+        "Use API Key auth for realtime features."
+    );
+  }
+
+  async handleUnauthorized(): Promise<boolean> {
+    this.accessToken = null;
+    try {
+      await this.ensureToken();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async ensureToken(): Promise<string> {
+    if (this.accessToken) return this.accessToken;
+    if (this.tokenPromise) return this.tokenPromise;
+
+    this.tokenPromise = this.acquireToken();
+    try {
+      this.accessToken = await this.tokenPromise;
+      this.scheduleRefresh();
+      return this.accessToken;
+    } finally {
+      this.tokenPromise = null;
+    }
+  }
+
+  private async acquireToken(): Promise<string> {
+    const clientToken = await this.tokenProvider({
+      context: {
+        publicKey: this.publicKey,
+        baseUrl: this.baseUrl,
+        agentCode: this.agentCode,
+      },
+    });
+
+    const response = await fetch(
+      `${this.baseUrl}/v2/Agent/${encodeURIComponent(this.agentCode)}/ClientCredential/Token`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          publicKey: this.publicKey,
+          token: clientToken,
+        }),
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Token exchange failed: ${response.status}`);
+    }
+
+    const { accessToken } = await response.json();
+    return accessToken;
+  }
+
+  private scheduleRefresh(): void {
+    if (this.refreshTimer) clearInterval(this.refreshTimer);
+    // Refresh every 14 minutes (tokens typically expire at 15 min)
+    this.refreshTimer = setInterval(() => {
+      this.accessToken = null;
+      this.ensureToken().catch(() => {});
+    }, 14 * 60 * 1000);
+  }
+
+  destroy(): void {
+    if (this.refreshTimer) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+  }
+}

--- a/packages/sdk/src/auth/index.ts
+++ b/packages/sdk/src/auth/index.ts
@@ -1,0 +1,26 @@
+import { AuthProvider } from "./AuthProvider";
+import { ApiKeyAuthProvider } from "./ApiKeyAuthProvider";
+import { TokenAuthProvider } from "./TokenAuthProvider";
+import { SerenityClientOptions } from "../types";
+
+export { AuthProvider } from "./AuthProvider";
+export { ApiKeyAuthProvider } from "./ApiKeyAuthProvider";
+export { TokenAuthProvider } from "./TokenAuthProvider";
+
+const DEFAULT_BASE_URL = "https://api.serenitystar.ai/api";
+
+export function createAuthProvider(
+  options: SerenityClientOptions
+): AuthProvider {
+  if ("apiKey" in options && options.apiKey) {
+    return new ApiKeyAuthProvider(options.apiKey);
+  }
+  const credentials = options.agentClientCredentials!;
+  const baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
+  return new TokenAuthProvider(
+    credentials.publicKey,
+    credentials.tokenProvider,
+    baseUrl,
+    credentials.agentCode
+  );
+}

--- a/packages/sdk/src/factories/AgentFactory.ts
+++ b/packages/sdk/src/factories/AgentFactory.ts
@@ -6,6 +6,7 @@ import { RealtimeSession } from "../scopes/conversational/RealtimeSession";
 import { Activity } from "../scopes/system/Activity";
 import { ChatCompletion } from "../scopes/system/ChatCompletion";
 import { Proxy } from "../scopes/system/Proxy";
+import { AuthProvider } from "../auth/AuthProvider";
 import {
   AgentSetupOptions,
   AgentResult,
@@ -17,7 +18,7 @@ import {
 export class AgentFactory {
   static createAgent<T extends AgentType>(
     type: T,
-    apiKey: string,
+    authProvider: AuthProvider,
     baseUrl: string
   ): AgentTypeMap[T] {
     switch (type) {
@@ -29,13 +30,13 @@ export class AgentFactory {
           ) => {
             const assistant = Assistant.create(
               agentCode,
-              apiKey,
+              authProvider,
               baseUrl,
               options
             );
             const conversation = await assistant.createConversation(
               agentCode,
-              apiKey,
+              authProvider,
               baseUrl,
               options
             );
@@ -47,21 +48,21 @@ export class AgentFactory {
           } = { showExecutorTaskLogs: false }): Promise<ConversationRes> => {
             const assistant = Assistant.create(
               agentCode,
-              apiKey,
+              authProvider,
               baseUrl
             );
-            const conversation = await assistant.createConversationWithoutInfo(agentCode, apiKey, baseUrl);
+            const conversation = assistant.createConversationWithoutInfo(agentCode, authProvider, baseUrl);
             return await conversation.getConversationById(conversationId, options);
           },
           getInfoByCode: async (agentCode: string, options?: AgentSetupOptions) => {
             const assistant = Assistant.create(
               agentCode,
-              apiKey,
+              authProvider,
               baseUrl,
               options);
             const conversation = await assistant.createConversation(
               agentCode,
-              apiKey,
+              authProvider,
               baseUrl,
               options
             );
@@ -73,13 +74,13 @@ export class AgentFactory {
           ) => {
             const assistant = Assistant.create(
               agentCode,
-              apiKey,
+              authProvider,
               baseUrl,
               options
             );
             return assistant.createRealtimeSession(
               agentCode,
-              apiKey,
+              authProvider,
               baseUrl,
               options
             );
@@ -92,10 +93,10 @@ export class AgentFactory {
             agentCode: string,
             options?: AgentSetupOptions
           ): Promise<Conversation> => {
-            const copilot = Copilot.create(agentCode, apiKey, baseUrl, options);
+            const copilot = Copilot.create(agentCode, authProvider, baseUrl, options);
             const conversation = await copilot.createConversation(
               agentCode,
-              apiKey,
+              authProvider,
               baseUrl,
               options
             );
@@ -106,21 +107,21 @@ export class AgentFactory {
           } = { showExecutorTaskLogs: false }): Promise<ConversationRes> => {
             const assistant = Assistant.create(
               agentCode,
-              apiKey,
+              authProvider,
               baseUrl
             );
-            const conversation = await assistant.createConversationWithoutInfo(agentCode, apiKey, baseUrl);
+            const conversation = assistant.createConversationWithoutInfo(agentCode, authProvider, baseUrl);
             return await conversation.getConversationById(conversationId, options);
           },
           getInfoByCode: async (agentCode: string, options?: AgentSetupOptions) => {
             const assistant = Assistant.create(
               agentCode,
-              apiKey,
+              authProvider,
               baseUrl,
               options);
             const conversation = await assistant.createConversation(
               agentCode,
-              apiKey,
+              authProvider,
               baseUrl,
               options
             );
@@ -130,10 +131,10 @@ export class AgentFactory {
             agentCode: string,
             options?: ConversationalAgentExecutionOptionsMap["copilot"]
           ) => {
-            const copilot = Copilot.create(agentCode, apiKey, baseUrl, options);
+            const copilot = Copilot.create(agentCode, authProvider, baseUrl, options);
             return copilot.createRealtimeSession(
               agentCode,
-              apiKey,
+              authProvider,
               baseUrl,
               options
             );
@@ -148,7 +149,7 @@ export class AgentFactory {
           ): Promise<AgentResult> => {
             return Activity["createAndExecute"](
               agentCode,
-              apiKey,
+              authProvider,
               baseUrl,
               options
             );
@@ -157,7 +158,7 @@ export class AgentFactory {
             agentCode: string,
             options?: SystemAgentExecutionOptionsMap["activity"]
           ): Activity => {
-            return Activity["create"](agentCode, apiKey, baseUrl, options);
+            return Activity["create"](agentCode, authProvider, baseUrl, options);
           },
         } as AgentTypeMap[T];
       }
@@ -169,7 +170,7 @@ export class AgentFactory {
           ): Promise<AgentResult> => {
             return ChatCompletion["createAndExecute"](
               agentCode,
-              apiKey,
+              authProvider,
               baseUrl,
               options
             );
@@ -180,7 +181,7 @@ export class AgentFactory {
           ): ChatCompletion => {
             return ChatCompletion["create"](
               agentCode,
-              apiKey,
+              authProvider,
               baseUrl,
               options
             );
@@ -195,7 +196,7 @@ export class AgentFactory {
           ): Promise<AgentResult> => {
             return Proxy["createAndExecute"](
               agentCode,
-              apiKey,
+              authProvider,
               baseUrl,
               options
             );
@@ -204,9 +205,93 @@ export class AgentFactory {
             agentCode: string,
             options?: SystemAgentExecutionOptionsMap["proxy"]
           ): Proxy => {
-            return Proxy["create"](agentCode, apiKey, baseUrl, options);
+            return Proxy["create"](agentCode, authProvider, baseUrl, options);
           },
         } as AgentTypeMap[T];
+      }
+      default:
+        throw new Error(`Agent type ${type} not supported`);
+    }
+  }
+
+  static createScopedAgent<T extends AgentType>(
+    type: T,
+    agentCode: string,
+    authProvider: AuthProvider,
+    baseUrl: string
+  ): ScopedAgentTypeMap[T] {
+    switch (type) {
+      case "assistant": {
+        return {
+          createConversation: async (options?: AgentSetupOptions) => {
+            const assistant = Assistant.create(agentCode, authProvider, baseUrl, options);
+            return await assistant.createConversation(agentCode, authProvider, baseUrl, options);
+          },
+          getConversationById: async (
+            conversationId: string,
+            options: { showExecutorTaskLogs: boolean } = { showExecutorTaskLogs: false }
+          ): Promise<ConversationRes> => {
+            const assistant = Assistant.create(agentCode, authProvider, baseUrl);
+            const conversation = assistant.createConversationWithoutInfo(agentCode, authProvider, baseUrl);
+            return await conversation.getConversationById(conversationId, options);
+          },
+          getInfo: async (options?: AgentSetupOptions) => {
+            const assistant = Assistant.create(agentCode, authProvider, baseUrl, options);
+            const conversation = await assistant.createConversation(agentCode, authProvider, baseUrl, options);
+            return conversation.info;
+          },
+        } as ScopedAgentTypeMap[T];
+      }
+      case "copilot": {
+        return {
+          createConversation: async (options?: AgentSetupOptions) => {
+            const copilot = Copilot.create(agentCode, authProvider, baseUrl, options);
+            return await copilot.createConversation(agentCode, authProvider, baseUrl, options);
+          },
+          getConversationById: async (
+            conversationId: string,
+            options: { showExecutorTaskLogs: boolean } = { showExecutorTaskLogs: false }
+          ): Promise<ConversationRes> => {
+            const assistant = Assistant.create(agentCode, authProvider, baseUrl);
+            const conversation = assistant.createConversationWithoutInfo(agentCode, authProvider, baseUrl);
+            return await conversation.getConversationById(conversationId, options);
+          },
+          getInfo: async (options?: AgentSetupOptions) => {
+            const assistant = Assistant.create(agentCode, authProvider, baseUrl, options);
+            const conversation = await assistant.createConversation(agentCode, authProvider, baseUrl, options);
+            return conversation.info;
+          },
+        } as ScopedAgentTypeMap[T];
+      }
+      case "activity": {
+        return {
+          execute: (options?: SystemAgentExecutionOptionsMap["activity"]): Promise<AgentResult> => {
+            return Activity["createAndExecute"](agentCode, authProvider, baseUrl, options);
+          },
+          create: (options?: SystemAgentExecutionOptionsMap["activity"]): Activity => {
+            return Activity["create"](agentCode, authProvider, baseUrl, options);
+          },
+        } as ScopedAgentTypeMap[T];
+      }
+      case "chat-completion": {
+        return {
+          execute: (options?: SystemAgentExecutionOptionsMap["chat-completion"]): Promise<AgentResult> => {
+            return ChatCompletion["createAndExecute"](agentCode, authProvider, baseUrl, options);
+          },
+          create: (options?: SystemAgentExecutionOptionsMap["chat-completion"]): ChatCompletion => {
+            return ChatCompletion["create"](agentCode, authProvider, baseUrl, options);
+          },
+        } as ScopedAgentTypeMap[T];
+      }
+      case "proxy": {
+        return {
+          execute: (options?: SystemAgentExecutionOptionsMap["proxy"]): Promise<AgentResult> => {
+            return Proxy["createAndExecute"](agentCode, authProvider, baseUrl, options);
+          },
+          create: (options?: SystemAgentExecutionOptionsMap["proxy"]): Proxy => {
+            return Proxy["create"](agentCode, authProvider, baseUrl, options);
+          },
+        } as ScopedAgentTypeMap[T];
       }
       default:
         throw new Error(`Agent type ${type} not supported`);
@@ -345,4 +430,44 @@ type AgentTypeMap = {
   activity: SystemAgentScope<"activity", Activity>;
   "chat-completion": SystemAgentScope<"chat-completion", ChatCompletion>;
   proxy: SystemAgentScope<"proxy", Proxy>;
+};
+
+// ─── Agent Client Credentials scopes (agentCode omitted) ───
+
+export type ScopedConversationalAgentScope<
+  T extends keyof ConversationalAgentExecutionOptionsMap,
+> = {
+  createConversation: (
+    options?: AgentSetupOptions
+  ) => Promise<Conversation>;
+
+  getInfo: (
+    options?: AgentSetupOptions
+  ) => Promise<ConversationInfoResult | null>;
+
+  getConversationById: (
+    conversationId: string,
+    options?: { showExecutorTaskLogs: boolean }
+  ) => Promise<ConversationRes>;
+};
+
+export type ScopedSystemAgentScope<
+  T extends keyof SystemAgentExecutionOptionsMap,
+  TCreateReturn,
+> = {
+  execute: (
+    options?: SystemAgentExecutionOptionsMap[T]
+  ) => Promise<AgentResult>;
+
+  create: (
+    options?: SystemAgentExecutionOptionsMap[T]
+  ) => TCreateReturn;
+};
+
+type ScopedAgentTypeMap = {
+  assistant: ScopedConversationalAgentScope<"assistant">;
+  copilot: ScopedConversationalAgentScope<"copilot">;
+  activity: ScopedSystemAgentScope<"activity", Activity>;
+  "chat-completion": ScopedSystemAgentScope<"chat-completion", ChatCompletion>;
+  proxy: ScopedSystemAgentScope<"proxy", Proxy>;
 };

--- a/packages/sdk/src/factories/ServiceFactory.ts
+++ b/packages/sdk/src/factories/ServiceFactory.ts
@@ -3,16 +3,17 @@ import {
   TranscribeAudioOptions,
   TranscribeAudioResult,
 } from "../types";
+import { AuthProvider } from "../auth/AuthProvider";
 
 export class ServiceFactory {
   static createService<T extends ServiceType>(
     type: T,
-    apiKey: string,
+    authProvider: AuthProvider,
     baseUrl: string
   ): ServiceTypeMap[T] {
     switch (type) {
       case "audio": {
-        const transcribeManager = new TranscribeAudioManager(baseUrl, apiKey);
+        const transcribeManager = new TranscribeAudioManager(baseUrl, authProvider);
         return {
           /**
            * Transcribe an audio file using the Serenity API.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -14,7 +14,8 @@ import {
   SubmitFeedbackResult,
 } from "./scopes/conversational/Conversation/types";
 import { RealtimeSession } from "./scopes/conversational/RealtimeSession";
-import SerenityClient from "./SerenityClient";
+import { SerenityClient, FullSerenityClient, ScopedSerenityClient } from "./SerenityClient";
+import type { FullAgents, FullServices, ScopedAgents } from "./SerenityClient";
 import {
   AgentResult,
   BaseErrorBody,
@@ -27,11 +28,15 @@ import {
   TranscribeAudioOptions,
   TranscribeAudioResult,
   FileUploadRes,
+  TokenProviderFn,
+  TokenProviderContext,
+  AgentClientCredentials,
 } from "./types";
 import { ExternalErrorHelper } from "./utils/ErrorHelper";
 import { VolatileKnowledgeManager } from "./utils/VolatileKnowledgeManager";
+import { AuthProvider } from "./auth/AuthProvider";
 
-export { SerenityClient, RealtimeSession, ExternalErrorHelper as ErrorHelper, VolatileKnowledgeManager };
+export { SerenityClient, FullSerenityClient, ScopedSerenityClient, RealtimeSession, ExternalErrorHelper as ErrorHelper, VolatileKnowledgeManager };
 export type {
   AgentResult,
   ConversationRes,
@@ -56,4 +61,11 @@ export type {
   TranscribeAudioResult,
   FileUploadRes,
   AttachedVolatileKnowledgeRes,
+  TokenProviderFn,
+  TokenProviderContext,
+  AgentClientCredentials,
+  AuthProvider,
+  FullAgents,
+  FullServices,
+  ScopedAgents,
 };

--- a/packages/sdk/src/scopes/conversational/Assistant.ts
+++ b/packages/sdk/src/scopes/conversational/Assistant.ts
@@ -1,22 +1,23 @@
 import { AgentSetupOptions } from "../../types";
+import { AuthProvider } from "../../auth/AuthProvider";
 import { ConversationalAgent } from "./ConversationalAgent";
 
 export class Assistant extends ConversationalAgent {
   private constructor(
     agentCode: string,
-    apiKey: string,
+    authProvider: AuthProvider,
     baseUrl: string,
     options?: AgentSetupOptions
   ) {
-    super(agentCode, apiKey, baseUrl, options);
+    super(agentCode, authProvider, baseUrl, options);
   }
   
   static create(
     agentCode: string,
-    apiKey: string,
+    authProvider: AuthProvider,
     baseUrl: string,
     options?: AgentSetupOptions
   ): Assistant {
-    return new Assistant(agentCode, apiKey, baseUrl, options);
+    return new Assistant(agentCode, authProvider, baseUrl, options);
   }
 }

--- a/packages/sdk/src/scopes/conversational/Conversation/index.ts
+++ b/packages/sdk/src/scopes/conversational/Conversation/index.ts
@@ -23,10 +23,12 @@ import { AgentMapper } from "../../../utils/AgentMapper";
 import { InternalErrorHelper } from "../../../utils/ErrorHelper";
 import { VolatileKnowledgeManager } from "../../../utils/VolatileKnowledgeManager";
 import { FileManager } from "../../../utils/FileManager";
+import { AuthProvider } from "../../../auth/AuthProvider";
+import { fetchWithAuth } from "../../../utils/fetchWithAuth";
 
 export class Conversation extends EventEmitter<SSEStreamEvents> {
   private agentCode: string;
-  private apiKey: string;
+  private authProvider: AuthProvider;
   private baseUrl: string;
 
   // Optional parameters.
@@ -56,16 +58,16 @@ export class Conversation extends EventEmitter<SSEStreamEvents> {
 
   private constructor(
     agentCode: string,
-    apiKey: string,
+    authProvider: AuthProvider,
     baseUrl: string,
     options?: AgentExecutionOptions
   ) {
     super();
-    this.apiKey = apiKey;
+    this.authProvider = authProvider;
     this.agentCode = agentCode;
     this.baseUrl = baseUrl;
-    this.volatileKnowledge = new VolatileKnowledgeManager(baseUrl, apiKey);
-    this.fileManager = new FileManager(baseUrl, apiKey);
+    this.volatileKnowledge = new VolatileKnowledgeManager(baseUrl, authProvider);
+    this.fileManager = new FileManager(baseUrl, authProvider);
 
     this.agentVersion = options?.agentVersion;
     this.userIdentifier = options?.userIdentifier;
@@ -76,21 +78,21 @@ export class Conversation extends EventEmitter<SSEStreamEvents> {
 
   private static async create(
     agentCode: string,
-    apiKey: string,
+    authProvider: AuthProvider,
     baseUrl: string,
     options?: AgentExecutionOptions
   ): Promise<Conversation> {
-    const instance = new Conversation(agentCode, apiKey, baseUrl, options);
+    const instance = new Conversation(agentCode, authProvider, baseUrl, options);
     await instance.getInfo();
     return instance;
   }
 
   private static createWithoutInfo(
     agentCode: string,
-    apiKey: string,
+    authProvider: AuthProvider,
     baseUrl: string
   ): Conversation {
-    return new Conversation(agentCode, apiKey, baseUrl);
+    return new Conversation(agentCode, authProvider, baseUrl);
   }
 
   async streamMessage(
@@ -201,10 +203,9 @@ export class Conversation extends EventEmitter<SSEStreamEvents> {
       url += `?${queryParams.toString()}`;
     }
 
-    const response = await fetch(url, {
+    const response = await fetchWithAuth(this.authProvider, url, {
       method: "GET",
       headers: {
-        "X-API-KEY": this.apiKey,
         "Content-Type": "application/json",
       },
     });
@@ -273,10 +274,9 @@ export class Conversation extends EventEmitter<SSEStreamEvents> {
       body.userIdentifier = this.userIdentifier;
     }
 
-    const response = await fetch(url, {
+    const response = await fetchWithAuth(this.authProvider, url, {
       method: "POST",
       headers: {
-        "X-API-KEY": this.apiKey,
         "Content-Type": "application/json",
       },
       body: JSON.stringify(body),
@@ -317,10 +317,9 @@ export class Conversation extends EventEmitter<SSEStreamEvents> {
 
     const url = `${this.baseUrl}/agent/${this.agentCode}/conversation/${this.conversationId}/message/${options.agentMessageId}/feedback`;
 
-    const response = await fetch(url, {
+    const response = await fetchWithAuth(this.authProvider, url, {
       method: "POST",
       headers: {
-        "X-API-KEY": this.apiKey,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
@@ -370,11 +369,9 @@ export class Conversation extends EventEmitter<SSEStreamEvents> {
 
     const url = `${this.baseUrl}/agent/${this.agentCode}/conversation/${this.conversationId}/message/${options.agentMessageId}/feedback`;
 
-    const response = await fetch(url, {
+    const response = await fetchWithAuth(this.authProvider, url, {
       method: "DELETE",
-      headers: {
-        "X-API-KEY": this.apiKey,
-      },
+      headers: {},
     });
 
     if (response.status !== 200) {
@@ -411,10 +408,9 @@ export class Conversation extends EventEmitter<SSEStreamEvents> {
   async getConnectorStatus(options: GetConnectorStatusOptions): Promise<ConnectorStatusResult> {
     const url = `${this.baseUrl}/connection/agentInstance/${options.agentInstanceId}/connector/${options.connectorId}/status`;
 
-    const response = await fetch(url, {
+    const response = await fetchWithAuth(this.authProvider, url, {
       method: "GET",
       headers: {
-        "X-API-KEY": this.apiKey,
         "Content-Type": "application/json",
       },
     });
@@ -436,11 +432,10 @@ export class Conversation extends EventEmitter<SSEStreamEvents> {
     const url = this.#getExecuteUrl();
     const body = this.#createExecuteBody(bodyOptions);
 
-    const response = await fetch(url, {
+    const response = await fetchWithAuth(this.authProvider, url, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "X-API-KEY": this.apiKey,
       },
       body: JSON.stringify(body),
     });
@@ -502,11 +497,12 @@ export class Conversation extends EventEmitter<SSEStreamEvents> {
         resolve(finalMessage.result);
       });
 
+      const authHeaders = await this.authProvider.getHeaders();
       const fetchOptions: RequestInit = {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-API-KEY": this.apiKey,
+          ...authHeaders,
         },
         body: JSON.stringify(body),
       };

--- a/packages/sdk/src/scopes/conversational/ConversationalAgent.ts
+++ b/packages/sdk/src/scopes/conversational/ConversationalAgent.ts
@@ -1,38 +1,39 @@
 import { AgentSetupOptions } from "../../types";
+import { AuthProvider } from "../../auth/AuthProvider";
 import { Conversation } from "./Conversation";
 import { RealtimeSession } from "./RealtimeSession";
 
 export abstract class ConversationalAgent {
   protected constructor(
     protected readonly agentCode: string,
-    protected readonly apiKey: string,
+    protected readonly authProvider: AuthProvider,
     protected readonly baseUrl: string,
     protected readonly options?: AgentSetupOptions
   ) {}
 
   createRealtimeSession(
     agentCode: string,
-    apiKey: string,
+    authProvider: AuthProvider,
     baseUrl: string,
     options?: AgentSetupOptions
   ): RealtimeSession {
-    return new RealtimeSession(agentCode, apiKey, baseUrl, options);
+    return new RealtimeSession(agentCode, authProvider, baseUrl, options);
   }
 
   async createConversation(
     agentCode: string,
-    apiKey: string,
+    authProvider: AuthProvider,
     baseUrl: string,
     options?: AgentSetupOptions
   ): Promise<Conversation> {
-    return Conversation["create"](agentCode, apiKey, baseUrl, options);
+    return Conversation["create"](agentCode, authProvider, baseUrl, options);
   }
 
   createConversationWithoutInfo(
     agentCode: string,
-    apiKey: string,
+    authProvider: AuthProvider,
     baseUrl: string
   ): Conversation {
-    return Conversation["createWithoutInfo"](agentCode, apiKey, baseUrl);
+    return Conversation["createWithoutInfo"](agentCode, authProvider, baseUrl);
   }
 }

--- a/packages/sdk/src/scopes/conversational/Copilot.ts
+++ b/packages/sdk/src/scopes/conversational/Copilot.ts
@@ -1,22 +1,23 @@
 import { AgentSetupOptions } from "../../types";
+import { AuthProvider } from "../../auth/AuthProvider";
 import { ConversationalAgent } from "./ConversationalAgent";
 
 export class Copilot extends ConversationalAgent {
   constructor(
     agentCode: string,
-    apiKey: string,
+    authProvider: AuthProvider,
     baseUrl: string,
     options?: AgentSetupOptions
   ) {
-    super(agentCode, apiKey, baseUrl, options);
+    super(agentCode, authProvider, baseUrl, options);
   }
 
   static create(
       agentCode: string,
-      apiKey: string,
+      authProvider: AuthProvider,
       baseUrl: string,
       options?: AgentSetupOptions
     ): Copilot {
-      return new Copilot(agentCode, apiKey, baseUrl, options);
+      return new Copilot(agentCode, authProvider, baseUrl, options);
     }
 }

--- a/packages/sdk/src/scopes/conversational/RealtimeSession/index.ts
+++ b/packages/sdk/src/scopes/conversational/RealtimeSession/index.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "../../../EventEmitter";
 import { AgentSetupOptions } from "../../../types";
+import { AuthProvider } from "../../../auth/AuthProvider";
 import {
   RealtimeSessionEvents,
   SerenitySessionCreateEvent,
@@ -13,7 +14,7 @@ import {
 
 export class RealtimeSession extends EventEmitter<RealtimeSessionEvents> {
   private agentCode: string;
-  private apiKey: string;
+  private authProvider: AuthProvider;
   private baseUrl: string;
 
   // Optional parameters.
@@ -36,12 +37,12 @@ export class RealtimeSession extends EventEmitter<RealtimeSessionEvents> {
 
   constructor(
     agentCode: string,
-    apiKey: string,
+    authProvider: AuthProvider,
     baseUrl: string,
     options?: AgentSetupOptions
   ) {
     super();
-    this.apiKey = apiKey;
+    this.authProvider = authProvider;
     this.agentCode = agentCode;
     this.baseUrl = baseUrl;
 
@@ -58,7 +59,7 @@ export class RealtimeSession extends EventEmitter<RealtimeSessionEvents> {
    */
   async start(): Promise<void> {
     try {
-      this.#setupWebSocketConnection();
+      await this.#setupWebSocketConnection();
     } catch (error) {
       throw new Error(`Error starting the session`);
     }
@@ -132,14 +133,15 @@ export class RealtimeSession extends EventEmitter<RealtimeSessionEvents> {
     clearTimeout(this.inactivityTimeout);
   }
 
-  #setupWebSocketConnection() {
+  async #setupWebSocketConnection() {
     let url = `${this.baseUrl}/v2/agent/${this.agentCode}/realtime`;
 
     if (this.agentVersion) {
       url += `/${this.agentVersion}`;
     }
 
-    this.socket = new WebSocket(url, ["X-API-KEY", this.apiKey]);
+    const protocols = await this.authProvider.getWebSocketProtocols();
+    this.socket = new WebSocket(url, protocols);
 
     this.socket.onopen = () => {
       const sessionCreateEvent: SerenitySessionCreateEvent = {

--- a/packages/sdk/src/scopes/system/Activity.ts
+++ b/packages/sdk/src/scopes/system/Activity.ts
@@ -3,33 +3,34 @@ import {
   ExecuteBodyParams,
   SystemAgentExecutionOptionsMap,
 } from "./../../types";
+import { AuthProvider } from "../../auth/AuthProvider";
 
 export class Activity extends SystemAgent<"activity"> {
   private constructor(
     agentCode: string,
-    apiKey: string,
+    authProvider: AuthProvider,
     baseUrl: string,
     options?: SystemAgentExecutionOptionsMap["activity"]
   ) {
-    super(agentCode, apiKey, baseUrl, options);
+    super(agentCode, authProvider, baseUrl, options);
   }
 
   static create(
     agentCode: string,
-    apiKey: string,
+    authProvider: AuthProvider,
     baseUrl: string,
     options?: SystemAgentExecutionOptionsMap["activity"]
   ): Activity {
-    return new Activity(agentCode, apiKey, baseUrl, options);
+    return new Activity(agentCode, authProvider, baseUrl, options);
   }
 
   static createAndExecute(
     agentCode: string,
-    apiKey: string,
+    authProvider: AuthProvider,
     baseUrl: string,
     options?: SystemAgentExecutionOptionsMap["activity"]
   ) {
-    const instance = new Activity(agentCode, apiKey, baseUrl, options);
+    const instance = new Activity(agentCode, authProvider, baseUrl, options);
     return instance.execute();
   }
 

--- a/packages/sdk/src/scopes/system/ChatCompletion.ts
+++ b/packages/sdk/src/scopes/system/ChatCompletion.ts
@@ -1,33 +1,34 @@
 import { ExecuteBodyParams } from "../../types";
 import { SystemAgentExecutionOptionsMap } from "./../../types";
 import { SystemAgent } from "./SystemAgent";
+import { AuthProvider } from "../../auth/AuthProvider";
 
 export class ChatCompletion extends SystemAgent<"chat-completion"> {
   private constructor(
     agentCode: string,
-    apiKey: string,
+    authProvider: AuthProvider,
     baseUrl: string,
     options?: SystemAgentExecutionOptionsMap["chat-completion"]
   ) {
-    super(agentCode, apiKey, baseUrl, options);
+    super(agentCode, authProvider, baseUrl, options);
   }
 
   static create(
     agentCode: string,
-    apiKey: string,
+    authProvider: AuthProvider,
     baseUrl: string,
     options?: SystemAgentExecutionOptionsMap["chat-completion"]
   ): ChatCompletion {
-    return new ChatCompletion(agentCode, apiKey, baseUrl, options);
+    return new ChatCompletion(agentCode, authProvider, baseUrl, options);
   }
 
   static createAndExecute(
     agentCode: string,
-    apiKey: string,
+    authProvider: AuthProvider,
     baseUrl: string,
     options?: SystemAgentExecutionOptionsMap["chat-completion"]
   ) {
-    const instance = new ChatCompletion(agentCode, apiKey, baseUrl, options);
+    const instance = new ChatCompletion(agentCode, authProvider, baseUrl, options);
     return instance.execute();
   }
 

--- a/packages/sdk/src/scopes/system/Proxy.ts
+++ b/packages/sdk/src/scopes/system/Proxy.ts
@@ -1,33 +1,34 @@
 import { SystemAgent } from "./SystemAgent";
 import { ExecuteBodyParams, SystemAgentExecutionOptionsMap } from "../../types";
 import { ProxyExecutionOptions } from "./types";
+import { AuthProvider } from "../../auth/AuthProvider";
 
 export class Proxy extends SystemAgent<"proxy"> {
   private constructor(
     agentCode: string,
-    apiKey: string,
+    authProvider: AuthProvider,
     baseUrl: string,
     options?: SystemAgentExecutionOptionsMap["proxy"]
   ) {
-    super(agentCode, apiKey, baseUrl, options);
+    super(agentCode, authProvider, baseUrl, options);
   }
 
   static create(
     agentCode: string,
-    apiKey: string,
+    authProvider: AuthProvider,
     baseUrl: string,
     options?: SystemAgentExecutionOptionsMap["proxy"]
   ): Proxy {
-    return new Proxy(agentCode, apiKey, baseUrl, options);
+    return new Proxy(agentCode, authProvider, baseUrl, options);
   }
 
   static createAndExecute(
     agentCode: string,
-    apiKey: string,
+    authProvider: AuthProvider,
     baseUrl: string,
     options?: SystemAgentExecutionOptionsMap["proxy"]
   ) {
-    const instance = new Proxy(agentCode, apiKey, baseUrl, options);
+    const instance = new Proxy(agentCode, authProvider, baseUrl, options);
     return instance.execute();
   }
 

--- a/packages/sdk/src/scopes/system/SystemAgent.ts
+++ b/packages/sdk/src/scopes/system/SystemAgent.ts
@@ -6,6 +6,8 @@ import { VolatileKnowledgeManager } from "../../utils/VolatileKnowledgeManager";
 import { FileManager } from "../../utils/FileManager";
 import { SseConnection } from "../conversational/Conversation/SseConnection";
 import { SystemAgentExecutionOptionsMap } from "./../../types";
+import { AuthProvider } from "../../auth/AuthProvider";
+import { fetchWithAuth } from "../../utils/fetchWithAuth";
 
 export abstract class SystemAgent<
   T extends keyof SystemAgentExecutionOptionsMap,
@@ -28,13 +30,13 @@ export abstract class SystemAgent<
 
   protected constructor(
     protected readonly agentCode: string,
-    protected readonly apiKey: string,
+    protected readonly authProvider: AuthProvider,
     protected readonly baseUrl: string,
     protected readonly options?: SystemAgentExecutionOptionsMap[T]
   ) {
     super();
-    this.volatileKnowledge = new VolatileKnowledgeManager(baseUrl, apiKey);
-    this.fileManager = new FileManager(baseUrl, apiKey);
+    this.volatileKnowledge = new VolatileKnowledgeManager(baseUrl, authProvider);
+    this.fileManager = new FileManager(baseUrl, authProvider);
   }
 
   /**
@@ -158,11 +160,10 @@ export abstract class SystemAgent<
   ): Promise<AgentResult> {
     const url = this.#getExecuteUrl();
 
-    const response = await fetch(url, {
+    const response = await fetchWithAuth(this.authProvider, url, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "X-API-KEY": this.apiKey,
       },
       body: JSON.stringify(body),
     });
@@ -216,11 +217,12 @@ export abstract class SystemAgent<
         resolve(finalMessage.result);
       });
 
+      const authHeaders = await this.authProvider.getHeaders();
       const fetchOptions: RequestInit = {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-API-KEY": this.apiKey,
+          ...authHeaders,
         },
         body: JSON.stringify(body),
       };

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,18 +1,49 @@
 import { ProxyExecutionOptions } from "./scopes/system/types";
 
+/** Context passed to the tokenProvider callback */
+export type TokenProviderContext = {
+  publicKey: string;
+  /** The base URL of the Serenity API */
+  baseUrl: string;
+  /** The agent code this token is scoped to */
+  agentCode: string;
+};
+
+/** The tokenProvider function signature */
+export type TokenProviderFn = (params: {
+  context: TokenProviderContext;
+}) => Promise<string>;
+
+/** Agent Client Credentials — scoped to a single agent */
+export type AgentClientCredentials = {
+  /** The agent this credential is scoped to */
+  agentCode: string;
+  /** The public key issued for this agent */
+  publicKey: string;
+  /** Callback to obtain a client token from your backend */
+  tokenProvider: TokenProviderFn;
+};
+
+/** API Key auth mode — full access */
+export type ApiKeyClientOptions = {
+  apiKey: string;
+  agentClientCredentials?: never;
+  baseUrl?: string;
+};
+
+/** Agent Client Credentials auth mode — scoped to one agent */
+export type AgentClientCredentialsOptions = {
+  apiKey?: never;
+  agentClientCredentials: AgentClientCredentials;
+  baseUrl?: string;
+};
+
 /**
  * Options for configuring the Serenity client.
  */
-export type SerenityClientOptions = {
-  /**
-   * The API key used for authenticating requests to the Serenity API.
-   */
-  apiKey: string;
-  /**
-   * The base URL of the Serenity API.
-   */
-  baseUrl?: string;
-};
+export type SerenityClientOptions =
+  | ApiKeyClientOptions
+  | AgentClientCredentialsOptions;
 
 export type AgentType = 'assistant' | 'copilot' | 'proxy' | 'activity' | 'chat-completion';
 

--- a/packages/sdk/src/utils/FileManager.ts
+++ b/packages/sdk/src/utils/FileManager.ts
@@ -1,13 +1,15 @@
 import { FileUploadOptions, FileUploadRes } from "../types";
 import { InternalErrorHelper } from "./ErrorHelper";
+import { AuthProvider } from "../auth/AuthProvider";
+import { fetchWithAuth } from "./fetchWithAuth";
 
 export class FileManager {
   baseUrl: string;
-  apiKey: string;
+  authProvider: AuthProvider;
 
-  constructor(baseUrl: string, apiKey: string) {
+  constructor(baseUrl: string, authProvider: AuthProvider) {
     this.baseUrl = baseUrl;
-    this.apiKey = apiKey;
+    this.authProvider = authProvider;
   }
 
   /**
@@ -82,12 +84,10 @@ export class FileManager {
     formData.append("formFile", fileToUpload, fileName);
 
     try {
-      const response = await fetch(url, {
+      const response = await fetchWithAuth(this.authProvider, url, {
         method: "POST",
         body: formData,
-        headers: {
-          "X-API-KEY": this.apiKey,
-        },
+        headers: {},
       });
 
       if (!response.ok) {

--- a/packages/sdk/src/utils/TranscribeAudioManager.ts
+++ b/packages/sdk/src/utils/TranscribeAudioManager.ts
@@ -4,6 +4,8 @@ import {
   FileUploadRes,
 } from "../types";
 import { InternalErrorHelper } from "./ErrorHelper";
+import { AuthProvider } from "../auth/AuthProvider";
+import { fetchWithAuth } from "./fetchWithAuth";
 
 /**
  * Supported audio MIME types for Gemini API
@@ -50,7 +52,7 @@ export class TranscribeAudioManager {
   public audioFileId: string | null = null;
   constructor(
     private readonly baseUrl: string,
-    private readonly apiKey: string
+    private readonly authProvider: AuthProvider
   ) {}
 
   /**
@@ -99,12 +101,10 @@ export class TranscribeAudioManager {
     }
 
     try {
-      const response = await fetch(url, {
+      const response = await fetchWithAuth(this.authProvider, url, {
         method: "POST",
         body: formData,
-        headers: {
-          "X-API-KEY": this.apiKey,
-        },
+        headers: {},
       });
 
       if (!response.ok) {

--- a/packages/sdk/src/utils/VolatileKnowledgeManager.ts
+++ b/packages/sdk/src/utils/VolatileKnowledgeManager.ts
@@ -3,6 +3,8 @@ import {
   VolatileKnowledgeUploadRes,
 } from "../types";
 import { InternalErrorHelper } from "./ErrorHelper";
+import { AuthProvider } from "../auth/AuthProvider";
+import { fetchWithAuth } from "./fetchWithAuth";
 
 /**
  * Manages volatile knowledge files for agent instances.
@@ -13,7 +15,7 @@ export class VolatileKnowledgeManager {
 
   constructor(
     private readonly baseUrl: string,
-    private readonly apiKey: string
+    private readonly authProvider: AuthProvider
   ) {}
 
   /**
@@ -61,12 +63,11 @@ export class VolatileKnowledgeManager {
     }
 
     try {
-      const response = await fetch(`${url}?${queryParams.toString()}`, {
+      const response = await fetchWithAuth(this.authProvider, `${url}?${queryParams.toString()}`, {
         method: "POST",
         body: formData,
         headers: {
           contentType: "multipart/form-data",
-          "X-API-KEY": this.apiKey,
         },
       });
 
@@ -176,11 +177,10 @@ export class VolatileKnowledgeManager {
   async getById(fileId: string): Promise<VolatileKnowledgeUploadRes> {
     const url = `${this.baseUrl}/v2/volatileKnowledge/${fileId}`;
 
-    const result = await fetch(url, {
+    const result = await fetchWithAuth(this.authProvider, url, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
-        "X-API-KEY": this.apiKey,
       },
     });
 

--- a/packages/sdk/src/utils/fetchWithAuth.ts
+++ b/packages/sdk/src/utils/fetchWithAuth.ts
@@ -1,0 +1,26 @@
+import { AuthProvider } from "../auth/AuthProvider";
+
+export async function fetchWithAuth(
+  authProvider: AuthProvider,
+  url: string,
+  options: RequestInit
+): Promise<Response> {
+  const authHeaders = await authProvider.getHeaders();
+  const response = await fetch(url, {
+    ...options,
+    headers: { ...options.headers, ...authHeaders },
+  });
+
+  if (response.status === 401) {
+    const retried = await authProvider.handleUnauthorized(response);
+    if (retried) {
+      const newHeaders = await authProvider.getHeaders();
+      return fetch(url, {
+        ...options,
+        headers: { ...options.headers, ...newHeaders },
+      });
+    }
+  }
+
+  return response;
+}


### PR DESCRIPTION
## feat: Agent Client Credentials authentication mode (`v2.5.0`)

This release introduces a second authentication mode — **Agent Client Credentials** — designed for client-side applications that should not embed long-lived API keys.

### What's new

**Two authentication modes are now supported:**

**API Key** (existing, unchanged)
```ts
const client = new SerenityClient({ apiKey: "sk_..." });
```
Full access to all agents and services. No changes to existing usage.

**Agent Client Credentials** (new)
```ts
const client = new SerenityClient({
  agentClientCredentials: {
    agentCode: "chef-assistant",
    publicKey: "<PUBLIC_KEY>",
    tokenProvider: async ({ context }) => {
      // Call your own backend to obtain a client token
      const res = await fetch("/api/get-serenity-token", { ... });
      return (await res.json()).token;
    },
  },
});
```
- Scopes the client to a **single agent** — `agentCode` is fixed at construction and omitted from all method calls.
- Your `tokenProvider` callback only needs to return a client token from your backend. The SDK handles the token exchange, and refreshes it proactively before expiry.
- Automatically retries requests on `401` after re-acquiring a fresh token.

### Considerations

- When using Agent Client Credentials, `client.services` (e.g. audio transcription) is not available.
- `createRealtimeSession` is not available with this auth mode — realtime features require API Key authentication.
- The `SerenityClient` constructor is overloaded: TypeScript will infer the correct client type (`FullSerenityClient` or `ScopedSerenityClient`) based on the options you pass, giving you accurate autocomplete and type safety for what's available in each mode.
- **No breaking changes** for existing API Key users.

### New exported types

`TokenProviderFn`, `TokenProviderContext`, `AgentClientCredentials`, `FullAgents`, `FullServices`, `ScopedAgents`, `AuthProvider`