### PR TITLE
feat: adds download attachment method for conversations

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenity-star/sdk",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "The Serenity Star JavaScript SDK provides a convenient way to interact with the Serenity Star API, enabling you to build custom applications.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/sdk/readme.md
+++ b/packages/sdk/readme.md
@@ -753,6 +753,41 @@ console.log(
 
 # Shared Features
 
+## Download Attached Files
+
+Download files attached to assistant/copilot messages through the SDK (auth handled automatically for both API Key and Token Provider modes).
+
+```tsx
+import SerenityClient from '@serenity-star/sdk';
+
+const client = new SerenityClient({
+  apiKey: '<SERENITY_API_KEY>',
+});
+
+const conversation = await client.agents.assistants.createConversation("document-analyzer");
+
+// Example attachment URL from message.attached_volatile_knowledges[index].download_url
+const blob = await conversation.downloadAttachment("https://api.serenitystar.ai/api/file/download/<file-id>");
+
+// Trigger browser download
+const url = URL.createObjectURL(blob);
+const a = document.createElement("a");
+a.href = url;
+a.download = "document.pdf";
+a.click();
+URL.revokeObjectURL(url);
+```
+
+> **Token Provider Auth:** Same API.
+> ```ts
+> const client = new SerenityClient({
+>   agentClientCredentials: { agentCode: "chef-assistant", publicKey: "<PUBLIC_KEY>", tokenProvider },
+> });
+>
+> const conversation = await client.agents.assistants.createConversation();
+> const blob = await conversation.downloadAttachment("https://api.serenitystar.ai/api/file/download/<file-id>");
+> ```
+
 ## Stop Streaming Response
 
 You can stop a streaming response at any time by calling `stop()`. This works across all agent types: **Assistants**, **Copilots**, **Activities**, **Proxies**, and **Chat Completions**.

--- a/packages/sdk/src/scopes/conversational/Conversation/index.ts
+++ b/packages/sdk/src/scopes/conversational/Conversation/index.ts
@@ -165,6 +165,16 @@ export class Conversation extends EventEmitter<SSEStreamEvents> {
   }
 
   /**
+   * Download an attached file from a conversation message.
+   *
+   * @param downloadUrl - Attachment download URL
+   * @returns The downloaded attachment as a Blob
+   */
+  async downloadAttachment(downloadUrl: string): Promise<Blob> {
+    return await this.fileManager.download(downloadUrl);
+  }
+
+  /**
    * Stops the current streaming response, aborting the SSE connection.
    * If no stream is active, this method does nothing.
    * 

--- a/packages/sdk/src/utils/FileManager.ts
+++ b/packages/sdk/src/utils/FileManager.ts
@@ -107,4 +107,29 @@ export class FileManager {
       throw error;
     }
   }
+
+  /**
+   * Download a file using an authenticated request.
+   *
+   * @param downloadUrl - Absolute or relative file download URL
+   * @returns The downloaded file as a Blob
+   */
+  async download(downloadUrl: string): Promise<Blob> {
+    const normalizedUrl = downloadUrl.startsWith("http")
+      ? downloadUrl
+      : `${this.baseUrl}${downloadUrl.startsWith("/") ? "" : "/"}${downloadUrl}`;
+
+    const response = await fetchWithAuth(this.authProvider, normalizedUrl, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      throw await InternalErrorHelper.process(response, "Failed to download file");
+    }
+
+    return await response.blob();
+  }
 }


### PR DESCRIPTION
## SDK v2.5.1 — Download Attached Files

**What's new**

Conversations now expose a `downloadAttachment()` method that lets you download files attached to assistant/copilot messages. Authentication is handled automatically for both API Key and Token Provider setups — no extra headers or token wiring needed on your end.

**Usage**

```ts
const blob = await conversation.downloadAttachment(
  message.attached_volatile_knowledges[0].download_url
);
```

Works across all conversational agent types (Assistants, Copilots). Full examples added to the README.