### PR TITLE
fix: update input parameters order in Conversation class so clients c…

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenity-star/sdk",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "The Serenity Star JavaScript SDK provides a convenient way to interact with the Serenity Star API, enabling you to build custom applications.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/sdk/src/scopes/conversational/Conversation/index.ts
+++ b/packages/sdk/src/scopes/conversational/Conversation/index.ts
@@ -580,8 +580,8 @@ export class Conversation extends EventEmitter<SSEStreamEvents> {
     this.#appendInputParametersIfNeeded(
       body,
       {
-      ...(options.additionalInfo?.inputParameters ?? {}),
-      ...(this.inputParameters ?? {})
+        ...(this.inputParameters ?? {}),
+        ...(options.additionalInfo?.inputParameters ?? {})
       }
     );
     


### PR DESCRIPTION
## Summary
Fix the orden in which we make the spread for input parameters during execution. This allows clients to override current input parameters with new values on each execution.
 
## Evidence
 
Payload in the first message
<img width="814" height="313" alt="image" src="https://github.com/user-attachments/assets/eb0fe26e-d6da-4761-98fe-ddbd15b4a68c" />

Payload in the second message
<img width="888" height="296" alt="image" src="https://github.com/user-attachments/assets/0f0e4d03-0ed1-457f-b138-47a4c460f644" />
 
## Type of Change
- [x] Bug fix
- [ ] Feature
- [ ] Issue
- [ ] Refactor
 
## Checklists
 
### Security
- [x] Security impact of change has been considered
- [x] Backwards compatibility has been checked, if applicable (migrations, API contract)
 
### General
 
- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request linked to task tracker where applicable
- [x] Videos or Image evidence clearly show the developed functionality
- [x] Developer has auto reviewed the pulled request
- [x] Tags have been added if applicable (migration, log migration, etc)
- [x] Branch name follows convention ({version}/{sprint}/{workItemType}/{workItemNumber})
- [x] Changes have been reviewed by at least one other contributor
 
---
*Serenity Star - Pull Request Template v.1 [2026-05-08]*
---