### PR TITLE
Add citations support in SDK for knowledge grounding

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenity-star/sdk",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "The Serenity Star JavaScript SDK provides a convenient way to interact with the Serenity Star API, enabling you to build custom applications.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/sdk/readme.md
+++ b/packages/sdk/readme.md
@@ -36,7 +36,9 @@ The Serenity Star JS/TS SDK provides a comprehensive interface for interacting w
   - [Execute a chat completion](#execute-a-chat-completion)
   - [Stream responses with SSE](#stream-responses-with-sse-2)
 - [Shared Features](#shared-features)
+  - [Download Attached Files](#download-attached-files)
   - [Stop Streaming Response](#stop-streaming-response)
+  - [Citations](#citations)
   - [Upload Files (Volatile Knowledge)](#upload-files-volatile-knowledge)
   - [Audio Input](#audio-input)
     - [Send Audio Messages (Assistants/Copilots)](#send-audio-messages-assistantscopilots)
@@ -312,8 +314,14 @@ const client = new SerenityClient({
 const conversation = await client.agents.assistants.createConversation("chef-assistant")
 	
 conversation
-	.on("content", (chunk) => {
+	.on("content", (chunk, citations) => {
 	  console.log(chunk) // Response chunk
+	  // `citations` is an optional array attached to some chunks.
+	  // Each citation's start_index / end_index are offsets into the FULL accumulated
+	  // message, not into this individual chunk.
+	  if (citations) {
+	    console.log(citations) // CitationRes[]
+	  }
 	})
 	.on("error", (error) => {
 	  // Handle stream errors here
@@ -327,9 +335,12 @@ console.log(
   response.content, // "Sure! Here is a recipe for parmesan chicken..."
   response.completion_usage, // { completion_tokens: 200, prompt_tokens: 30, total_tokens: 230 }
   response.executor_task_logs, // [ { description: 'Task 1', duration: 100 }, { description: 'Task 2', duration: 500 }],
+  response.citations, // CitationRes[] — full citation list for the final message
   response.instance_id, // instance id for the conversation
 )
 ```
+
+> **Citations:** When the agent grounds its answer in knowledge sources, citations are delivered both incrementally on `content` events (second argument) and as a consolidated `response.citations` array on the final result. See [Citations](#citations) for the full shape.
 
 ## Real time conversation
 
@@ -830,6 +841,85 @@ const activity = client.agents.activities.create("translator-activity", {
 });
 
 await activity.stream();
+```
+
+## Citations
+
+When an agent grounds its response in knowledge sources (knowledge files or websites), it returns **citations** that map spans of the generated message back to the source passages they came from. Citations are available across all agent types that support knowledge grounding.
+
+Citations are delivered in two places:
+
+1. **Incrementally**, as the second argument of the `content` event during streaming.
+2. **Consolidated**, as the `citations` array on the final result (`response.citations`) — available for both streamed and non-streamed executions.
+
+```tsx
+import SerenityClient from '@serenity-star/sdk';
+
+const client = new SerenityClient({
+  apiKey: '<SERENITY_API_KEY>',
+});
+
+const conversation = await client.agents.assistants.createConversation("policy-assistant");
+
+conversation.on("content", (chunk, citations) => {
+  process.stdout.write(chunk);
+
+  if (citations) {
+    for (const citation of citations) {
+      console.log(
+        citation.citation_index, // Display number rendered as the superscript (may repeat)
+        citation.start_index,    // Offset into the FULL accumulated message where the cited span starts
+        citation.end_index,      // Offset into the FULL accumulated message where the cited span ends
+        citation.relevance,      // Optional relevance score
+        citation.cited_text,     // Verbatim text of the source passage (shown in the hover card)
+        citation.source          // The cited source (see below), or null
+      );
+    }
+  }
+});
+
+const response = await conversation.streamMessage("Summarize our security and access-control requirements");
+
+// The final result carries the consolidated citation list
+for (const citation of response.citations ?? []) {
+  if (citation.source?.type === "knowledge_file") {
+    console.log(`[${citation.citation_index}] ${citation.source.file_name} (pages ${citation.source.page_range})`);
+  } else if (citation.source?.type === "knowledge_website") {
+    console.log(`[${citation.citation_index}] ${citation.source.website}`);
+  }
+}
+```
+
+> **Note:** `start_index` and `end_index` are offsets into the **full accumulated message**, not into the individual chunk delivered by a `content` event. Accumulate the chunks (or use `response.content`) before resolving these offsets.
+
+The `CitationRes` and `CitationSource` types are exported from the package:
+
+```ts
+import type { CitationRes, CitationSource } from '@serenity-star/sdk';
+
+type CitationSource =
+  | {
+      type: "knowledge_file";
+      knowledge_file_version_id?: string;
+      section_id?: string;
+      file_name?: string;
+      page_range?: string;
+    }
+  | {
+      type: "knowledge_website";
+      knowledge_file_version_id?: string;
+      section_id?: string;
+      website: string;
+    };
+
+type CitationRes = {
+  cited_text: string;      // Verbatim text of the source passage (shown in the hover card)
+  citation_index: number;  // Display number rendered as the superscript; may repeat across citations
+  start_index: number;     // Offset into the FULL accumulated message where the cited span starts
+  end_index: number;       // Offset into the FULL accumulated message where the cited span ends
+  relevance?: number;
+  source: CitationSource | null;
+};
 ```
 
 ## Upload Files (Volatile Knowledge)

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -18,6 +18,8 @@ import { SerenityClient, FullSerenityClient, ScopedSerenityClient } from "./Sere
 import type { FullAgents, FullServices, ScopedAgents } from "./SerenityClient";
 import {
   AgentResult,
+  CitationRes,
+  CitationSource,
   BaseErrorBody,
   FileError,
   PendingAction,
@@ -44,6 +46,8 @@ import { AuthProvider } from "./auth/AuthProvider";
 export { SerenityClient, FullSerenityClient, ScopedSerenityClient, RealtimeSession, ExternalErrorHelper as ErrorHelper, VolatileKnowledgeManager };
 export type {
   AgentResult,
+  CitationRes,
+  CitationSource,
   ConversationRes,
   ConversationInfoResult,
   ChatWidgetRes,

--- a/packages/sdk/src/scopes/conversational/Conversation/index.ts
+++ b/packages/sdk/src/scopes/conversational/Conversation/index.ts
@@ -493,7 +493,7 @@ export class Conversation extends EventEmitter<SSEStreamEvents> {
 
       this.connection.on("content", (data) => {
         const chunk = JSON.parse(data);
-        this.emit("content", chunk.text);
+        this.emit("content", chunk.text, chunk.citations);
       });
 
       this.connection.on("stop", (data) => {

--- a/packages/sdk/src/scopes/system/SystemAgent.ts
+++ b/packages/sdk/src/scopes/system/SystemAgent.ts
@@ -206,7 +206,7 @@ export abstract class SystemAgent<
 
       this.connection.on("content", (data) => {
         const chunk = JSON.parse(data);
-        this.emit("content", chunk.text);
+        this.emit("content", chunk.text, chunk.citations);
       });
 
       this.connection.on("stop", (data) => {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -125,6 +125,30 @@ export type PendingAction = {
   connector_id?: string;
 }
 
+export type CitationSource =
+  | {
+      type: "knowledge_file";
+      knowledge_file_version_id?: string;
+      section_id?: string;
+      file_name?: string;
+      page_range?: string;
+    }
+  | {
+      type: "knowledge_website";
+      knowledge_file_version_id?: string;
+      section_id?: string;
+      website: string;
+    };
+
+export type CitationRes = {
+  cited_text: string;
+  citation_index: number;
+  start_index: number;
+  end_index: number;
+  relevance?: number;
+  source: CitationSource | null;
+};
+
 export type AgentResult = {
   content: string;
   instance_id: string;
@@ -139,6 +163,7 @@ export type AgentResult = {
   agent_message_id?: string;
   user_message_id?: string;
   pending_actions?: PendingAction[];
+  citations?: CitationRes[];
 }
 
 /**
@@ -178,9 +203,11 @@ export type SSEStreamEvents = {
 
   /**
    * Event triggered when there is a new chunk of data available.
-   * @param data - The data chunk.
+   * @param data - The text of the chunk.
+   * @param citations - Optional citations attached to this chunk. Each citation's
+   * `start_index`/`end_index` are offsets into the full accumulated message, not this chunk.
    */
-  content: (data: string) => void;
+  content: (data: string, citations?: CitationRes[]) => void;
 
   /**
    * Event triggered when the server stops streaming a response.

--- a/packages/sdk/src/utils/AgentMapper.ts
+++ b/packages/sdk/src/utils/AgentMapper.ts
@@ -13,6 +13,7 @@ export class AgentMapper {
       json_content: data.jsonContent,
       meta_analysis: data.metaAnalysis,
       time_to_first_token: data.timeToFirstToken,
+      citations: data.citations,
     };
 
     return result;


### PR DESCRIPTION
## Summary

Adds **citations support** to the JS/TS SDK so that agents which ground their answers in knowledge sources (knowledge files or websites) can return the source passages backing each span of the generated message.

Key changes:

- **New exported types** in [packages/sdk/src/types.ts](packages/sdk/src/types.ts): `CitationRes` (a cited span with `cited_text`, `citation_index`, `start_index`, `end_index`, optional `relevance`, and a `source`) and `CitationSource` (a discriminated union of `knowledge_file` and `knowledge_website`). Both are re-exported from [packages/sdk/src/index.ts](packages/sdk/src/index.ts).
- **`AgentResult.citations`**: the consolidated citation list is now part of the final result for both streamed and non-streamed executions.
- **Streaming `content` event** now emits citations as an optional second argument (`content: (data: string, citations?: CitationRes[]) => void`). Updated for both [Conversation](packages/sdk/src/scopes/conversational/Conversation/index.ts) and [SystemAgent](packages/sdk/src/scopes/system/SystemAgent.ts) scopes.
- **`AgentMapper`** now maps `citations` from the underlying response into the public `AgentResult`.
- **Documentation**: a new [Citations](packages/sdk/readme.md) section in the README, plus updated streaming examples and table of contents.
- Bumps the SDK version to **2.6.1**.

> **Note:** Each citation's `start_index` / `end_index` are offsets into the **full accumulated message**, not into the individual chunk delivered by a `content` event.

## Evidence

New information was fully tested against other clients like the Chat Widget

## Type of Change
- [ ] Bug fix
- [x] Feature
- [ ] Issue
- [ ] Refactor

## Checklists

### Security
- [x] Security impact of change has been considered
- [x] Backwards compatibility has been checked, if applicable (migrations, API contract)

> The `content` event gains an optional second argument and `AgentResult` gains an optional `citations` field — both additive and backwards compatible. Existing handlers continue to work unchanged.

### General

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request linked to task tracker where applicable
- [x] Videos or Image evidence clearly show the developed functionality
- [x] Developer has auto reviewed the pulled request
- [ ] Tags have been added if applicable (migration, log migration, etc)
- [x] Branch name follows convention ({version}/{sprint}/{workItemType}/{workItemNumber})
- [ ] Changes have been reviewed by at least one other contributor

---
*Serenity Star - Pull Request Template v.1 [2026-05-08]*
---