### PR TITLE
Adds support for citations on stored conversation messages

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenity-star/sdk",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "The Serenity Star JavaScript SDK provides a convenient way to interact with the Serenity Star API, enabling you to build custom applications.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/sdk/readme.md
+++ b/packages/sdk/readme.md
@@ -39,6 +39,7 @@ The Serenity Star JS/TS SDK provides a comprehensive interface for interacting w
   - [Download Attached Files](#download-attached-files)
   - [Stop Streaming Response](#stop-streaming-response)
   - [Citations](#citations)
+    - [Citations on stored messages](#citations-on-stored-messages)
   - [Upload Files (Volatile Knowledge)](#upload-files-volatile-knowledge)
   - [Audio Input](#audio-input)
     - [Send Audio Messages (Assistants/Copilots)](#send-audio-messages-assistantscopilots)
@@ -257,7 +258,7 @@ const conversation = await client.agents.assistants.getConversationById("<agent-
 
 console.log(
   conversation.id, // "<conversation-id>"
-  conversation.messages, // Array of messages
+  conversation.messages, // Array of messages (each may include a `citations` array — see Citations)
   conversation.open // Boolean that indicates if the conversation was closed or not
 );
 
@@ -847,10 +848,11 @@ await activity.stream();
 
 When an agent grounds its response in knowledge sources (knowledge files or websites), it returns **citations** that map spans of the generated message back to the source passages they came from. Citations are available across all agent types that support knowledge grounding.
 
-Citations are delivered in two places:
+Citations are delivered in three places:
 
 1. **Incrementally**, as the second argument of the `content` event during streaming.
 2. **Consolidated**, as the `citations` array on the final result (`response.citations`) — available for both streamed and non-streamed executions.
+3. **Persisted**, on each `Message` loaded from conversation history (`message.citations`) — see [Citations on stored messages](#citations-on-stored-messages) below.
 
 ```tsx
 import SerenityClient from '@serenity-star/sdk';
@@ -892,10 +894,10 @@ for (const citation of response.citations ?? []) {
 
 > **Note:** `start_index` and `end_index` are offsets into the **full accumulated message**, not into the individual chunk delivered by a `content` event. Accumulate the chunks (or use `response.content`) before resolving these offsets.
 
-The `CitationRes` and `CitationSource` types are exported from the package:
+The `CitationRes`, `CitationResWithoutText`, and `CitationSource` types are exported from the package:
 
 ```ts
-import type { CitationRes, CitationSource } from '@serenity-star/sdk';
+import type { CitationRes, CitationResWithoutText, CitationSource } from '@serenity-star/sdk';
 
 type CitationSource =
   | {
@@ -920,6 +922,36 @@ type CitationRes = {
   relevance?: number;
   source: CitationSource | null;
 };
+
+// Same shape as CitationRes but without `cited_text`. Used for citations on
+// messages loaded from conversation history (see "Get conversation by id").
+type CitationResWithoutText = {
+  citation_index: number;
+  start_index: number;
+  end_index: number;
+  relevance?: number;
+  source: CitationSource | null;
+};
+```
+
+### Citations on stored messages
+
+Citations are also persisted on the conversation history. When you load past messages via [Get conversation by id](#get-conversation-by-id) (or read `conversation.messages`), each `Message` may carry a `citations` array of type `CitationResWithoutText[]` — the same shape as `CitationRes` but **without** the `cited_text` field (the verbatim passage is not stored alongside historical messages).
+
+```tsx
+const conversation = await client.agents.assistants.getConversationById("policy-assistant", "<conversation-id>");
+
+for (const message of conversation.messages) {
+  for (const citation of message.citations ?? []) {
+    console.log(
+      citation.citation_index, // Display number rendered as the superscript (may repeat)
+      citation.start_index,    // Offset into the message `value` where the cited span starts
+      citation.end_index,      // Offset into the message `value` where the cited span ends
+      citation.relevance,      // Optional relevance score
+      citation.source          // The cited source (knowledge_file / knowledge_website), or null
+    );
+  }
+}
 ```
 
 ## Upload Files (Volatile Knowledge)

--- a/packages/sdk/src/scopes/conversational/Conversation/types.ts
+++ b/packages/sdk/src/scopes/conversational/Conversation/types.ts
@@ -1,4 +1,4 @@
-import { ExecuteBodyParams, VolatileKnowledgeUploadRes } from "../../../types";
+import { CitationResWithoutText, VolatileKnowledgeUploadRes } from "../../../types";
 
 export type MessageAdditionalInfo = {
   inputParameters?: { [key: string]: any }
@@ -193,6 +193,7 @@ export type Message = (
   action_results?: {
     [key: string]: PluginExecutionResult
   }
+  citations?: CitationResWithoutText[];
 };
 
 type PluginExecutionResult = SpeechGenerationResult

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -149,6 +149,14 @@ export type CitationRes = {
   source: CitationSource | null;
 };
 
+export type CitationResWithoutText = {
+  citation_index: number;
+  start_index: number;
+  end_index: number;
+  relevance?: number;
+  source: CitationSource | null;
+};
+
 export type AgentResult = {
   content: string;
   instance_id: string;


### PR DESCRIPTION
## Summary
> Adds support for **citations on stored conversation messages**. Previously citations were only available incrementally during streaming and consolidated on the execution result (`response.citations`). Now, citations are also persisted on conversation history: each `Message` loaded via `getConversationById` (or read from `conversation.messages`) may carry a `citations` array.
>
> Because the verbatim passage (`cited_text`) is not stored alongside historical messages, a new `CitationResWithoutText` type is introduced — identical to `CitationRes` but without the `cited_text` field.
>
> **Changes:**
> - Added `CitationResWithoutText` type to [packages/sdk/src/types.ts](packages/sdk/src/types.ts) and exported it.
> - Added optional `citations?: CitationResWithoutText[]` field to `Message` in [packages/sdk/src/scopes/conversational/Conversation/types.ts](packages/sdk/src/scopes/conversational/Conversation/types.ts).
> - Documented the new "Citations on stored messages" section, updated the citations delivery list (two → three places), and the type export examples in [packages/sdk/readme.md](packages/sdk/readme.md).
> - Bumped package version `2.6.1` → `2.6.2` in [packages/sdk/package.json](packages/sdk/package.json).

## Evidence

> ```ts
> const conversation = await client.agents.assistants.getConversationById("policy-assistant", "<conversation-id>");
>
> for (const message of conversation.messages) {
>   for (const citation of message.citations ?? []) {
>     console.log(
>       citation.citation_index,
>       citation.start_index,
>       citation.end_index,
>       citation.relevance,
>       citation.source
>     );
>   }
> }
> ```

## Type of Change
- [ ] Bug fix
- [x] Feature
- [ ] Issue
- [ ] Refactor

## Checklists

### Security
- [x] Security impact of change has been considered
- [x] Backwards compatibility has been checked, if applicable (migrations, API contract) — *new `citations` field is optional; `CitationResWithoutText` is additive. No breaking changes.*

### General

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request linked to task tracker where applicable — *Work item 146717*
- [x] Videos or Image evidence clearly show the developed functionality
- [x] Developer has auto reviewed the pulled request
- [x] Tags have been added if applicable (migration, log migration, etc)
- [x] Branch name follows convention ({version}/{sprint}/{workItemType}/{workItemNumber})
- [x] Changes have been reviewed by at least one other contributor

---
*Serenity Star - Pull Request Template v.1 [2026-05-08]*
---