### PR TITLE
v2.6.3 - Fix Volatile Knowledge endpoint

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenity-star/sdk",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "The Serenity Star JavaScript SDK provides a convenient way to interact with the Serenity Star API, enabling you to build custom applications.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/sdk/src/utils/VolatileKnowledgeManager.ts
+++ b/packages/sdk/src/utils/VolatileKnowledgeManager.ts
@@ -33,6 +33,10 @@ export class VolatileKnowledgeManager {
     return `${this.baseUrl}/v2/agent/${encodeURIComponent(this.agentCode)}/volatileKnowledge`;
   }
 
+  private get oldVolatileKnowledgeUrl(): string {
+    return `${this.baseUrl}/v2/volatileKnowledge`;
+  }
+
   /**
    * Get the MIME types supported by the current agent for volatile knowledge uploads.
    */
@@ -302,7 +306,7 @@ export class VolatileKnowledgeManager {
    * @returns The file details or an error
    */
   async getById(fileId: string): Promise<VolatileKnowledgeUploadRes> {
-    const url = `${this.volatileKnowledgeUrl}/${fileId}`;
+    const url = `${this.oldVolatileKnowledgeUrl}/${fileId}`;
 
     const result = await fetchWithAuth(this.authProvider, url, {
       method: "GET",


### PR DESCRIPTION
## Summary
Fix volatile knowledge "getByid" endpoint to use the old path for the moment.
 
## Evidence
 
GetById was tested with the chat widget component
 
## Type of Change
- [x] Bug fix
- [ ] Feature
- [ ] Issue
- [ ] Refactor
 
## Checklists
 
### Security
- [x] Security impact of change has been considered
- [x] Backwards compatibility has been checked, if applicable (migrations, API contract)
 
### General
 
- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request linked to task tracker where applicable
- [x] Videos or Image evidence clearly show the developed functionality
- [x] Developer has auto reviewed the pulled request
- [x] Tags have been added if applicable (migration, log migration, etc)
- [x] Branch name follows convention ({version}/{sprint}/{workItemType}/{workItemNumber})
- [ ] Changes have been reviewed by at least one other contributor
 
---
*Serenity Star - Pull Request Template v.1 [2026-05-08]*
---