### PR TITLE
feat: add reasoning event for streaming chain-of-thought

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenity-star/sdk",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "description": "The Serenity Star JavaScript SDK provides a convenient way to interact with the Serenity Star API, enabling you to build custom applications.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/sdk/readme.md
+++ b/packages/sdk/readme.md
@@ -38,6 +38,7 @@ The Serenity Star JS/TS SDK provides a comprehensive interface for interacting w
 - [Shared Features](#shared-features)
   - [Download Attached Files](#download-attached-files)
   - [Stop Streaming Response](#stop-streaming-response)
+  - [Reasoning (Chain-of-Thought)](#reasoning-chain-of-thought)
   - [Citations](#citations)
     - [Citations on stored messages](#citations-on-stored-messages)
   - [Upload Files (Volatile Knowledge)](#upload-files-volatile-knowledge)
@@ -842,6 +843,30 @@ const activity = client.agents.activities.create("translator-activity", {
 });
 
 await activity.stream();
+```
+
+## Reasoning (Chain-of-Thought)
+
+When an agent is configured with a reasoning-capable model, its chain-of-thought is streamed incrementally through the `reasoning` event, separate from the final answer delivered on `content`. This works across all streaming agent types: **Assistants**, **Copilots**, **Activities**, **Proxies**, and **Chat Completions**.
+
+```tsx
+import SerenityClient from '@serenity-star/sdk';
+
+const client = new SerenityClient({
+  apiKey: '<SERENITY_API_KEY>',
+});
+
+const conversation = await client.agents.assistants.createConversation("chef-assistant");
+
+conversation
+  .on("reasoning", (chunk) => {
+    process.stdout.write(chunk); // Stream the model's thinking as it happens
+  })
+  .on("content", (chunk) => {
+    process.stdout.write(chunk); // The final answer
+  });
+
+await conversation.streamMessage("Plan a three-course vegetarian dinner");
 ```
 
 ## Citations

--- a/packages/sdk/src/scopes/conversational/Conversation/index.ts
+++ b/packages/sdk/src/scopes/conversational/Conversation/index.ts
@@ -496,9 +496,14 @@ export class Conversation extends EventEmitter<SSEStreamEvents> {
         this.emit("content", chunk.text, chunk.citations);
       });
 
+      this.connection.on("reasoning", (data) => {
+        const chunk = JSON.parse(data);
+        this.emit("reasoning", chunk.text);
+      });
+
       this.connection.on("stop", (data) => {
         const finalMessage = JSON.parse(data) as { result: AgentResult };
-        
+
         if (!this.conversationId) {
           this.conversationId = finalMessage.result.instance_id;
         }

--- a/packages/sdk/src/scopes/system/SystemAgent.ts
+++ b/packages/sdk/src/scopes/system/SystemAgent.ts
@@ -209,9 +209,14 @@ export abstract class SystemAgent<
         this.emit("content", chunk.text, chunk.citations);
       });
 
+      this.connection.on("reasoning", (data) => {
+        const chunk = JSON.parse(data);
+        this.emit("reasoning", chunk.text);
+      });
+
       this.connection.on("stop", (data) => {
         const finalMessage = JSON.parse(data) as { result: AgentResult };
-        
+
         this.volatileKnowledge.clear();
         this.emit("stop", finalMessage.result);
         resolve(finalMessage.result);

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -223,6 +223,13 @@ export type SSEStreamEvents = {
   content: (data: string, citations?: CitationRes[]) => void;
 
   /**
+   * Event triggered when there is a new chunk of chain-of-thought / reasoning text.
+   * Streamed alongside `content` while the agent produces its response.
+   * @param data - The text of the reasoning chunk.
+   */
+  reasoning: (data: string) => void;
+
+  /**
    * Event triggered when the server stops streaming a response.
    * @param message - The final message object.
    * @param message.sender - The sender of the message, either "user" or "bot".


### PR DESCRIPTION
## Summary
Adds a new `reasoning` SSE event that streams the agent's chain-of-thought separately from the final answer delivered on `content`.

- New `reasoning` event wired up in both `Conversation` and `SystemAgent` stream handlers.
- Typed in `SSEStreamEvents` (`reasoning: (data: string) => void`).
- Documented with a brief example in the SDK readme.
- Bumped `@serenity-star/sdk` to `2.6.5`.

## Evidence
> _N/A — additive streaming event; no UI changes._

## Type of Change
- [ ] Bug fix
- [x] Feature
- [ ] Issue
- [ ] Refactor

## Checklists

### Security
- [x] Security impact of change has been considered
- [x] Backwards compatibility has been checked, if applicable (migrations, API contract)

### General

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request linked to task tracker where applicable
- [x] Videos or Image evidence clearly show the developed functionality
- [x] Developer has auto reviewed the pulled request
- [x] Tags have been added if applicable (migration, log migration, etc)
- [x] Branch name follows convention ({version}/{sprint}/{workItemType}/{workItemNumber})
- [ ] Changes have been reviewed by at least one other contributor

---
*Serenity Star - Pull Request Template v.1 [2026-05-08]*
---
