### PR TITLE
SDK - v2.6.7 - Update channel types to include new fab properties

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenity-star/sdk",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "description": "The Serenity Star JavaScript SDK provides a convenient way to interact with the Serenity Star API, enabling you to build custom applications.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/sdk/src/scopes/conversational/Conversation/types.ts
+++ b/packages/sdk/src/scopes/conversational/Conversation/types.ts
@@ -53,6 +53,8 @@ export type ChatWidgetRes = {
   theme: ThemeRes;
   enableFeedbackRecollection: boolean;
   targetAgentVersion?: number;
+  fabPhotoURL?: string;
+  closeFabOnOpen: boolean;
 }
 
 type EngagementMessageRes = {


### PR DESCRIPTION
## Summary
> Map new properties to customize the FAB (floating action button) in the agent channel for the chat widget.

Adds two new properties to the `ChatWidgetRes` type in the conversational SDK scope:
- `fabPhotoURL?: string` — optional custom image URL for the FAB.
- `closeFabOnOpen: boolean` — whether the FAB closes when the widget is opened.

Bumps the `@serenity-star/sdk` package version from `2.6.6` to `2.6.7`.

## Evidence

> Screenshots, videos, logs, or API request/response samples

_N/A — type-only mapping change._

## Type of Change
- [ ] Bug fix
- [x] Feature
- [ ] Issue
- [ ] Refactor

## Checklists

### Security
- [x] Security impact of change has been considered
- [x] Backwards compatibility has been checked, if applicable (migrations, API contract)

### General

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request linked to task tracker where applicable
- [x] Videos or Image evidence clearly show the developed functionality
- [x] Developer has auto reviewed the pulled request
- [x] Tags have been added if applicable (migration, log migration, etc)
- [x] Branch name follows convention ({version}/{sprint}/{workItemType}/{workItemNumber})
- [ ] Changes have been reviewed by at least one other contributor

---
*Serenity Star - Pull Request Template v.1 [2026-05-08]*
---