### PR TITLE
feat(pricing): render typed feature rows from new SubscriptionPlan API

### DIFF
--- a/packages/pricing/package.json
+++ b/packages/pricing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenity-star/pricing",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A web component pricing section built with Svelte 5",
   "main": "dist/pricing.iife.js",
   "module": "dist/index.js",

--- a/packages/pricing/src/Plan.svelte
+++ b/packages/pricing/src/Plan.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { clsx } from "clsx";
-  import { CheckCircle2 } from "@lucide/svelte";
+  import { Check } from "@lucide/svelte";
+  import SquircleDashed from "./SquircleDashed.svelte";
   import type { PricingPlan } from "./types.js";
   import { getDefaults } from "./utils/i18n.js";
 
@@ -11,6 +12,8 @@
     typeOfPrice?: "monthly" | "annual";
     theme?: "light" | "dark";
     language?: "en" | "es";
+    /** Highest feature count across the plans rendered together. */
+    featureRowCount?: number;
   }
 
   let {
@@ -28,15 +31,38 @@
     showPrice = true,
     theme = "dark",
     language,
+    featureRowCount = 0,
   }: Props = $props();
 
   const isDark = $derived(theme === "dark");
   const i18n = $derived(getDefaults(language));
+
+  // The card is a subgrid of the pricing grid, so every plan sharing a grid row
+  // sizes the same tracks and its sections line up horizontally:
+  // 1 title, 2 price, 3 billing note, 4 description, 5 CTA, 6+ one row per feature.
+  const featuresRowStart = 6;
+  const featureRows = $derived(Math.max(featureRowCount, features.length, 1));
+  const totalRows = $derived(featuresRowStart - 1 + featureRows);
+
+  const iconClass = $derived(
+    clsx("h-6 w-6 flex-none", isPopular ? "text-white" : isDark ? "text-slate-400" : "text-slate-500")
+  );
+
+  // The chip takes the icon's place whenever a feature carries a value, so it
+  // matches the icon height and shares the same fixed-width leading slot to keep
+  // every label starting at the same offset.
+  const quantityClass = $derived(
+    clsx(
+      "inline-flex w-full h-6 items-center justify-center rounded-md px-0.5 text-xs font-semibold tabular-nums",
+      isPopular ? "bg-white/20 text-white" : isDark ? "bg-slate-800 text-white" : "bg-slate-100 text-slate-900"
+    )
+  );
 </script>
 
 <section
+  style="grid-row: span {totalRows};"
   class={clsx(
-    "flex flex-col rounded-3xl px-6 sm:px-8",
+    "grid grid-rows-subgrid gap-y-0 rounded-3xl px-6 sm:px-8 mb-10 2xl:mb-0",
     isPopular
       ? "bg-primary py-8 lg:order-0"
       : isDark
@@ -44,16 +70,16 @@
         : "border border-slate-200 lg:py-8 2xl:border-0"
   )}
 >
-  <h3 class={clsx("mt-5 font-display text-lg font-semibold", isPopular || isDark ? "text-white" : "text-slate-900")}>
+  <h3 class={clsx("row-start-1 mt-5 font-display text-lg font-semibold", isPopular || isDark ? "text-white" : "text-slate-900")}>
     {title}
   </h3>
-  <p class={clsx("font-display text-2xl font-light tracking-tight", isPopular || isDark ? "text-white" : "text-slate-900")}>
+  <p class={clsx("row-start-2 font-display text-2xl font-light tracking-tight", isPopular || isDark ? "text-white" : "text-slate-900")}>
     {typeOfPrice === "annual" ? annualPricePerMonth : monthlyPrice}
   </p>
 
   <p
     class={clsx(
-      "text-sm min-h-4",
+      "row-start-3 text-sm min-h-4",
       isPopular ? "text-slate-200" : isDark ? "text-slate-400" : "text-slate-500"
     )}
   >
@@ -65,7 +91,7 @@
   {#if description}
     <p
       class={clsx(
-        "mt-2 text-base",
+        "row-start-4 mt-2 text-base",
         isPopular ? "text-white" : isDark ? "text-slate-400" : "text-slate-600"
       )}
     >
@@ -75,20 +101,24 @@
 
   <ul
     role="list"
+    style="grid-row: {featuresRowStart} / span {featureRows};"
     class={clsx(
-      "order-last mt-10 mb-6 flex flex-col gap-y-3 text-sm",
+      "mt-6 grid grid-rows-subgrid gap-y-0 text-sm",
       isPopular ? "text-white" : isDark ? "text-slate-200" : "text-slate-700"
     )}
   >
-    {#each features as feature}
-      <li class="flex">
-        <CheckCircle2
-          class={clsx(
-            "h-6 w-6 flex-none",
-            isPopular ? "text-white" : isDark ? "text-slate-400" : "text-slate-500"
-          )}
-        />
-        <span class="ml-4">{feature}</span>
+    {#each features as feature, index}
+      <li class={clsx("flex items-start gap-x-3", index > 0 && "mt-3")}>
+        <span class="flex min-w-12 flex-none justify-center">
+          {#if feature.type === "Level"}
+            <Check class={iconClass} />
+          {:else if feature.value === null}
+            <SquircleDashed class={iconClass} />
+          {:else}
+            <span class={quantityClass}>{feature.value}</span>
+          {/if}
+        </span>
+        <span class="flex min-h-6 min-w-0 flex-1 items-center">{feature.text}</span>
       </li>
     {/each}
   </ul>
@@ -97,7 +127,7 @@
     <a
       href={ctaUrl}
       class={clsx(
-        "group inline-flex items-center justify-center rounded-full py-2 px-4 text-sm font-semibold focus-visible:outline-2 focus-visible:outline-offset-2 mt-8",
+        "group row-start-5 inline-flex items-center justify-center self-start rounded-full py-2 px-4 text-sm font-semibold focus-visible:outline-2 focus-visible:outline-offset-2 mt-2",
         isPopular
           ? "bg-white text-slate-900 hover:bg-slate-100 active:bg-slate-100 active:text-slate-900 focus-visible:outline-white"
           : isDark

--- a/packages/pricing/src/SquircleDashed.svelte
+++ b/packages/pricing/src/SquircleDashed.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  // Lucide's `squircle-dashed` (ISC). Inlined because @lucide/svelte 0.515 —
+  // the version this package pins — doesn't ship it yet; drop this in favour of
+  // `import { SquircleDashed } from "@lucide/svelte"` once lucide is bumped.
+  interface Props {
+    class?: string;
+  }
+
+  let { class: className }: Props = $props();
+</script>
+
+<svg
+  aria-hidden="true"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  class={className}
+>
+  <path d="M13.77 3.043a34 34 0 0 0-3.54 0" />
+  <path d="M13.771 20.956a33 33 0 0 1-3.541.001" />
+  <path d="M20.18 17.74c-.51 1.15-1.29 1.93-2.439 2.44" />
+  <path d="M20.18 6.259c-.51-1.148-1.291-1.929-2.44-2.438" />
+  <path d="M20.957 10.23a33 33 0 0 1 0 3.54" />
+  <path d="M3.043 10.23a34 34 0 0 0 .001 3.541" />
+  <path d="M6.26 20.179c-1.15-.508-1.93-1.29-2.44-2.438" />
+  <path d="M6.26 3.82c-1.149.51-1.93 1.291-2.44 2.44" />
+</svg>

--- a/packages/pricing/src/index.ts
+++ b/packages/pricing/src/index.ts
@@ -19,7 +19,7 @@ export function defineElement(tagName = 'serenity-pricing') {
 }
 
 // Export types
-export type { PricingPlan, PricingHeader } from './types.js';
+export type { PricingPlan, PricingHeader, PricingFeature, PricingFeatureType } from './types.js';
 
 // Export utility functions
 export { fetchPricingData } from './utils/api.js';

--- a/packages/pricing/src/styles.css
+++ b/packages/pricing/src/styles.css
@@ -21,6 +21,8 @@
     --spacing: 0.25rem;
     --container-2xl: 40rem;
     --container-7xl: 80rem;
+    --text-xs: 0.75rem;
+    --text-xs--line-height: calc(1 / 0.75);
     --text-sm: 0.875rem;
     --text-sm--line-height: calc(1.25 / 0.875);
     --text-base: 1rem;
@@ -37,6 +39,7 @@
     --font-weight-medium: 500;
     --font-weight-semibold: 600;
     --tracking-tight: -0.025em;
+    --radius-md: 0.375rem;
     --radius-3xl: 1.5rem;
     --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
     --default-transition-duration: 150ms;
@@ -221,8 +224,20 @@
   .serenity-pricing-root .left-0 {
     left: calc(var(--spacing) * 0);
   }
-  .serenity-pricing-root .order-last {
-    order: 9999;
+  .serenity-pricing-root .row-start-1 {
+    grid-row-start: 1;
+  }
+  .serenity-pricing-root .row-start-2 {
+    grid-row-start: 2;
+  }
+  .serenity-pricing-root .row-start-3 {
+    grid-row-start: 3;
+  }
+  .serenity-pricing-root .row-start-4 {
+    grid-row-start: 4;
+  }
+  .serenity-pricing-root .row-start-5 {
+    grid-row-start: 5;
   }
   .serenity-pricing-root .container {
     width: 100%;
@@ -251,26 +266,26 @@
   .serenity-pricing-root .mt-2 {
     margin-top: calc(var(--spacing) * 2);
   }
+  .serenity-pricing-root .mt-3 {
+    margin-top: calc(var(--spacing) * 3);
+  }
   .serenity-pricing-root .mt-4 {
     margin-top: calc(var(--spacing) * 4);
   }
   .serenity-pricing-root .mt-5 {
     margin-top: calc(var(--spacing) * 5);
   }
+  .serenity-pricing-root .mt-6 {
+    margin-top: calc(var(--spacing) * 6);
+  }
   .serenity-pricing-root .mt-8 {
     margin-top: calc(var(--spacing) * 8);
-  }
-  .serenity-pricing-root .mt-10 {
-    margin-top: calc(var(--spacing) * 10);
   }
   .serenity-pricing-root .mt-16 {
     margin-top: calc(var(--spacing) * 16);
   }
-  .serenity-pricing-root .mb-6 {
-    margin-bottom: calc(var(--spacing) * 6);
-  }
-  .serenity-pricing-root .ml-4 {
-    margin-left: calc(var(--spacing) * 4);
+  .serenity-pricing-root .mb-10 {
+    margin-bottom: calc(var(--spacing) * 10);
   }
   .serenity-pricing-root .flex {
     display: flex;
@@ -302,6 +317,9 @@
   .serenity-pricing-root .min-h-4 {
     min-height: calc(var(--spacing) * 4);
   }
+  .serenity-pricing-root .min-h-6 {
+    min-height: calc(var(--spacing) * 6);
+  }
   .serenity-pricing-root .w-5 {
     width: calc(var(--spacing) * 5);
   }
@@ -322,6 +340,15 @@
   }
   .serenity-pricing-root .max-w-\[80\%\] {
     max-width: 80%;
+  }
+  .serenity-pricing-root .min-w-0 {
+    min-width: calc(var(--spacing) * 0);
+  }
+  .serenity-pricing-root .min-w-12 {
+    min-width: calc(var(--spacing) * 12);
+  }
+  .serenity-pricing-root .flex-1 {
+    flex: 1;
   }
   .serenity-pricing-root .flex-none {
     flex: none;
@@ -346,11 +373,14 @@
   .serenity-pricing-root .grid-cols-1 {
     grid-template-columns: repeat(1, minmax(0, 1fr));
   }
-  .serenity-pricing-root .flex-col {
-    flex-direction: column;
+  .serenity-pricing-root .grid-rows-subgrid {
+    grid-template-rows: subgrid;
   }
   .serenity-pricing-root .items-center {
     align-items: center;
+  }
+  .serenity-pricing-root .items-start {
+    align-items: flex-start;
   }
   .serenity-pricing-root .justify-center {
     justify-content: center;
@@ -358,17 +388,27 @@
   .serenity-pricing-root .gap-3 {
     gap: calc(var(--spacing) * 3);
   }
-  .serenity-pricing-root .gap-y-3 {
-    row-gap: calc(var(--spacing) * 3);
+  .serenity-pricing-root .gap-x-3 {
+    -moz-column-gap: calc(var(--spacing) * 3);
+         column-gap: calc(var(--spacing) * 3);
   }
-  .serenity-pricing-root .gap-y-10 {
-    row-gap: calc(var(--spacing) * 10);
+  .serenity-pricing-root .gap-y-0 {
+    row-gap: calc(var(--spacing) * 0);
+  }
+  .serenity-pricing-root .gap-y-4 {
+    row-gap: calc(var(--spacing) * 4);
+  }
+  .serenity-pricing-root .self-start {
+    align-self: flex-start;
   }
   .serenity-pricing-root .rounded-3xl {
     border-radius: var(--radius-3xl);
   }
   .serenity-pricing-root .rounded-full {
     border-radius: calc(infinity * 1px);
+  }
+  .serenity-pricing-root .rounded-md {
+    border-radius: var(--radius-md);
   }
   .serenity-pricing-root .border {
     border-style: var(--tw-border-style);
@@ -399,14 +439,26 @@
   .serenity-pricing-root .bg-serenity-deep-blue {
     background-color: var(--color-serenity-deep-blue);
   }
+  .serenity-pricing-root .bg-slate-100 {
+    background-color: var(--color-slate-100);
+  }
   .serenity-pricing-root .bg-slate-300 {
     background-color: var(--color-slate-300);
   }
   .serenity-pricing-root .bg-slate-700 {
     background-color: var(--color-slate-700);
   }
+  .serenity-pricing-root .bg-slate-800 {
+    background-color: var(--color-slate-800);
+  }
   .serenity-pricing-root .bg-white {
     background-color: var(--color-white);
+  }
+  .serenity-pricing-root .bg-white\/20 {
+    background-color: color-mix(in srgb, #fff 20%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-white) 20%, transparent);
+    }
   }
   .serenity-pricing-root .fill-primary\/20 {
     fill: color-mix(in srgb, #4862ff 20%, transparent);
@@ -419,6 +471,9 @@
     @supports (color: color-mix(in lab, red, red)) {
       fill: color-mix(in oklab, var(--color-primary) 30%, transparent);
     }
+  }
+  .serenity-pricing-root .px-0\.5 {
+    padding-inline: calc(var(--spacing) * 0.5);
   }
   .serenity-pricing-root .px-4 {
     padding-inline: calc(var(--spacing) * 4);
@@ -457,6 +512,10 @@
   .serenity-pricing-root .text-sm {
     font-size: var(--text-sm);
     line-height: var(--tw-leading, var(--text-sm--line-height));
+  }
+  .serenity-pricing-root .text-xs {
+    font-size: var(--text-xs);
+    line-height: var(--tw-leading, var(--text-xs--line-height));
   }
   .serenity-pricing-root .font-light {
     --tw-font-weight: var(--font-weight-light);
@@ -503,6 +562,10 @@
   }
   .serenity-pricing-root .text-white {
     color: var(--color-white);
+  }
+  .serenity-pricing-root .tabular-nums {
+    --tw-numeric-spacing: tabular-nums;
+    font-variant-numeric: var(--tw-ordinal,) var(--tw-slashed-zero,) var(--tw-numeric-figure,) var(--tw-numeric-spacing,) var(--tw-numeric-fraction,);
   }
   .serenity-pricing-root .shadow {
     --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
@@ -675,6 +738,11 @@
            column-gap: calc(var(--spacing) * 4);
     }
   }
+  .serenity-pricing-root .\32 xl\:mb-0 {
+    @media (width >= 100rem) {
+      margin-bottom: calc(var(--spacing) * 0);
+    }
+  }
   .serenity-pricing-root .\32 xl\:grid-cols-5 {
     @media (width >= 100rem) {
       grid-template-columns: repeat(5, minmax(0, 1fr));
@@ -732,6 +800,26 @@
   inherits: false;
 }
 @property --tw-tracking {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-ordinal {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-slashed-zero {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-numeric-figure {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-numeric-spacing {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-numeric-fraction {
   syntax: "*";
   inherits: false;
 }
@@ -827,6 +915,11 @@
       --tw-border-style: solid;
       --tw-font-weight: initial;
       --tw-tracking: initial;
+      --tw-ordinal: initial;
+      --tw-slashed-zero: initial;
+      --tw-numeric-figure: initial;
+      --tw-numeric-spacing: initial;
+      --tw-numeric-fraction: initial;
       --tw-shadow: 0 0 #0000;
       --tw-shadow-color: initial;
       --tw-shadow-alpha: 100%;

--- a/packages/pricing/src/types.ts
+++ b/packages/pricing/src/types.ts
@@ -1,15 +1,40 @@
 import type { HTMLAttributes } from "svelte/elements";
 
+/**
+ * What a feature row describes:
+ * - `Highlight`: headline claim for the plan ("tokens / month").
+ * - `Quantity`: an entitlement with a numeric limit ("Rate limit - Per 12 hours").
+ * - `Level`: a tier for a named capability ("Cost Dashboard: Advanced").
+ *
+ * `Highlight` and `Quantity` both carry their number in `value` and render the
+ * same way; only `Level` is purely textual.
+ */
+export type PricingFeatureType = "Highlight" | "Quantity" | "Level";
+
+export interface PricingFeature {
+  type: PricingFeatureType;
+  /**
+   * The display-ready limit for `Highlight` and `Quantity` features ("10M"),
+   * already abbreviated by the API. `null` means "not included", and it is
+   * always `null` for `Level`.
+   */
+  value: string | null;
+  /** Label for the feature, without the number. */
+  text: string;
+}
+
 export interface PricingPlan {
   title: string;
   // New price fields: monthly and annual-per-month
   monthlyPrice: string;
   annualPricePerMonth: string;
-  features: string[];
+  features: PricingFeature[];
   href?: string;
   isPopular?: boolean;
   showPrice?: boolean;
   description?: string;
+  /** Ascending display order returned by the API. */
+  order?: number;
 }
 
 export interface PricingHeader {

--- a/packages/pricing/src/utils/api.ts
+++ b/packages/pricing/src/utils/api.ts
@@ -2,7 +2,7 @@ import type { PricingPlan } from '../types.js';
 
 export async function fetchPricingData(): Promise<PricingPlan[]> {
   try {
-    const response = await fetch('https://api.serenitystar.ai/api/SubscriptionPlan');
+    const response = await fetch('https://localhost:5002/api/SubscriptionPlan');
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }

--- a/packages/pricing/src/utils/api.ts
+++ b/packages/pricing/src/utils/api.ts
@@ -2,7 +2,7 @@ import type { PricingPlan } from '../types.js';
 
 export async function fetchPricingData(): Promise<PricingPlan[]> {
   try {
-    const response = await fetch('https://localhost:5002/api/SubscriptionPlan');
+    const response = await fetch('https://api.serenitystar.ai/api/SubscriptionPlan');
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }

--- a/packages/pricing/src/web-component/Pricing.svelte
+++ b/packages/pricing/src/web-component/Pricing.svelte
@@ -145,9 +145,6 @@
         <p class="{isDark ? 'text-slate-400' : 'text-slate-600'}">{i18n.noPlans}</p>
       </div>
     {:else}
-      <!-- row-gap must stay 0: the cards are row subgrids, so any row gap here is
-           applied between every internal row of every card. Cards space themselves
-           with mb-10 when they wrap onto more than one row band. -->
       <div class="-mx-4 mt-8 grid max-w-2xl grid-cols-1 gap-y-4 sm:mx-auto md:grid-cols-2 md:gap-x-8 lg:-mx-8 lg:max-w-none xl:mx-0 xl:grid-cols-3 xl:gap-x-4 2xl:grid-cols-5">
         {#each sortedPlans as plan}
           <Plan

--- a/packages/pricing/src/web-component/Pricing.svelte
+++ b/packages/pricing/src/web-component/Pricing.svelte
@@ -47,6 +47,14 @@
   
   // State for pricing data
   let plans = $state<PricingPlan[]>([]);
+
+  // The API assigns each plan a display order.
+  const sortedPlans = $derived([...plans].sort((a, b) => (a.order ?? 0) - (b.order ?? 0)));
+
+  // Drives how many grid rows every card spans, so all plans share the same tracks.
+  const maxFeatureCount = $derived(
+    plans.reduce((max, plan) => Math.max(max, plan.features?.length ?? 0), 0)
+  );
   let loading = $state(true);
   let error = $state<string | null>(null);
   
@@ -137,8 +145,11 @@
         <p class="{isDark ? 'text-slate-400' : 'text-slate-600'}">{i18n.noPlans}</p>
       </div>
     {:else}
-      <div class="-mx-4 mt-8 grid max-w-2xl grid-cols-1 gap-y-10 sm:mx-auto md:grid-cols-2 md:gap-x-8 lg:-mx-8 lg:max-w-none xl:mx-0 xl:grid-cols-3 xl:gap-x-4 2xl:grid-cols-5">
-        {#each plans as plan}
+      <!-- row-gap must stay 0: the cards are row subgrids, so any row gap here is
+           applied between every internal row of every card. Cards space themselves
+           with mb-10 when they wrap onto more than one row band. -->
+      <div class="-mx-4 mt-8 grid max-w-2xl grid-cols-1 gap-y-4 sm:mx-auto md:grid-cols-2 md:gap-x-8 lg:-mx-8 lg:max-w-none xl:mx-0 xl:grid-cols-3 xl:gap-x-4 2xl:grid-cols-5">
+        {#each sortedPlans as plan}
           <Plan
             title={plan.title}
             monthlyPrice={plan.monthlyPrice}
@@ -149,6 +160,7 @@
             isPopular={plan.isPopular}
             showPrice={plan.showPrice}
             typeOfPrice={selectedPrice}
+            featureRowCount={maxFeatureCount}
             {showCTA}
             ctaText={resolvedCtaText}
             {ctaUrl}


### PR DESCRIPTION
## Summary

Reworks `@serenity-star/pricing` to consume the new `SubscriptionPlan` API response, so feature rows communicate *what* they grant and *how much* instead of rendering an undifferentiated list of check-marked strings.

**API contract (breaking for the package's public types)**
- `PricingPlan.features` changes from `string[]` to `PricingFeature[]` — `{ type, value, text }`.
- New `PricingFeatureType`: `Highlight` (headline claim, e.g. "tokens / month"), `Quantity` (numeric entitlement, e.g. "Rate limit — per 12 hours"), `Level` (named capability tier, e.g. "Cost Dashboard: Advanced").
- `PricingFeature.value` holds the API's already-abbreviated limit (`"10M"`); `null` means *not included*, and is always `null` for `Level`.
- New optional `PricingPlan.order` — the API's ascending display order; plans are now sorted by it in `Pricing.svelte` rather than trusting array order.
- `PricingFeature` / `PricingFeatureType` are exported from the package entrypoint.

**Rendering**
- Each feature row's leading slot is now type-aware: a value chip for `Highlight`/`Quantity`, a `Check` for `Level`, and a dashed squircle for *not included* (`value === null`). The chip shares the icon's height and a fixed-width slot so every label starts at the same offset.
- Plan cards became row subgrids of the pricing grid, so title / price / billing note / description / CTA and every feature row line up horizontally across all plans. The card row span is driven by `featureRowCount`, computed in `Pricing.svelte` as the max feature count across plans.
- Added `SquircleDashed.svelte` — Lucide's `squircle-dashed` inlined because the pinned `@lucide/svelte` 0.515 doesn't ship it yet; the component comments the removal condition.
- `styles.css` regenerated for the new utilities (subgrid, row-start, gap-x, tabular-nums, etc.).

Package version bumped to `0.2.0`.

Related work item: AB#149296

## Evidence

> This screenshot is using mocked data
<img width="800" height="462" alt="image" src="https://github.com/user-attachments/assets/3fe2c8c8-db23-4340-8986-2218fb83a4f7" />

## Type of Change
- [ ] Bug fix
- [x] Feature
- [ ] Issue
- [x] Refactor

## Checklists

### Security
- [x] Security impact of change has been considered — no auth, storage, or user input involved; the component only GETs a public pricing endpoint and renders API-provided strings through Svelte's escaping template syntax (no `{@html}`).
- [x] Backwards compatibility has been checked, if applicable (migrations, API contract) — **this is a breaking change** for consumers of `@serenity-star/pricing`: `PricingPlan.features` is now `PricingFeature[]` instead of `string[]`, so any consumer constructing plans by hand must migrate. It requires the new `SubscriptionPlan` API response shape and will render empty feature slots against the old one. Shipped as a minor bump (`0.1.0` → `0.2.0`) on a pre-1.0 package.

### General

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request linked to task tracker where applicable
- [x] Videos or Image evidence clearly show the developed functionality
- [x] Developer has auto reviewed the pulled request
- [x] Tags have been added if applicable (migration, log migration, etc)
- [x] Branch name follows convention ({version}/{sprint}/{workItemType}/{workItemNumber})
- [ ] Changes have been reviewed by at least one other contributor

---
*Serenity Star - Pull Request Template v.1 [2026-05-08]*
---
