### PR TITLE
Expose task start and stop events in the conversational SDK

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenity-star/sdk",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "The Serenity Star JavaScript SDK provides a convenient way to interact with the Serenity Star API, enabling you to build custom applications.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/sdk/readme.md
+++ b/packages/sdk/readme.md
@@ -39,6 +39,7 @@ The Serenity Star JS/TS SDK provides a comprehensive interface for interacting w
   - [Download Attached Files](#download-attached-files)
   - [Stop Streaming Response](#stop-streaming-response)
   - [Reasoning (Chain-of-Thought)](#reasoning-chain-of-thought)
+  - [Task events](#task-events)
   - [Citations](#citations)
     - [Citations on stored messages](#citations-on-stored-messages)
   - [Upload Files (Volatile Knowledge)](#upload-files-volatile-knowledge)
@@ -914,6 +915,83 @@ conversation
   });
 
 await conversation.streamMessage("Plan a three-course vegetarian dinner");
+```
+
+## Task events
+
+While an agent streams, it reports the internal work it performs through the `task_start` / `task_stop` event pair. A **task** is any discrete step the agent runs on its way to an answer — a skill execution, a tool call, and whatever step types the platform adds later. The SDK forwards every task frame it receives without filtering, so new task types reach your handlers as soon as the platform starts emitting them.
+
+Use them to reflect the agent's progress in your UI while it works, or to time, trace and log what the agent actually did.
+
+These events only exist on **streamed** executions (`streamMessage` / `stream`). A non-streamed call returns the final result only.
+
+Each task carries a `task_key` identifying what ran and a `metadata` object describing it. Both are task-type specific: match on `task_key` for the types you care about and ignore the rest, rather than assuming a single shape.
+
+```tsx
+import SerenityClient from '@serenity-star/sdk';
+
+const client = new SerenityClient({
+  apiKey: '<SERENITY_API_KEY>',
+});
+
+const conversation = await client.agents.assistants.createConversation("sales-assistant");
+
+conversation
+  .on("task_start", (task) => console.log("started", task.task, task.task_key))
+  .on("task_stop", (task) =>
+    console.log("finished", task.task_key, task.duration, task.success)
+  )
+  .on("content", (chunk) => process.stdout.write(chunk));
+
+await conversation.streamMessage("What do we have in stock for vintage guitars?");
+```
+
+### `task_start` payload
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `type` | `string` | The event name, `task_start`. |
+| `task` | `string` | Human-readable description of the task, safe to show in a UI. |
+| `task_key` | `string` | Identifier of what ran. Its format depends on the task type. |
+| `metadata` | `object` | Extra details about the task. Contents depend on the task type. |
+| `start_time_utc` | `string` | When the task started (UTC). |
+| `input` | `object` | The arguments the task was invoked with. Shape depends on the task. |
+
+### `task_stop` payload
+
+Same envelope as `task_start`, plus:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `end_time_utc` | `string` | When the task finished (UTC). |
+| `duration` | `string` | Elapsed time as a timespan string, e.g. `00:00:00.0002104`. |
+| `success` | `boolean` | Whether the task completed successfully. |
+| `output` | `any` | The task's result. Shape depends on the task. |
+
+Unknown fields the server may add in the future are preserved on the payload — both types carry an index signature.
+
+### Recognising a task type
+
+Skill executions are one task type. Their `task_key` follows the `skills_<SkillCode>_execute` convention, and the skill is described under `metadata.skill`:
+
+```json
+{
+  "type": "task_start",
+  "task": "Executing Skill: GetProductInfo",
+  "task_key": "skills_GetProductInfo_execute",
+  "metadata": { "skill": { "type": "Prompt", "code": "GetProductInfo" } },
+  "start_time_utc": "2026-08-24T10:22:54.1822224Z",
+  "input": { "categoryName": "Music instruments from the 1960s" }
+}
+```
+
+```tsx
+conversation.on("task_start", (task) => {
+  const skillCode = task.metadata?.skill?.code;
+  if (skillCode) {
+    showSpinner(`Running ${skillCode}…`);
+  }
+});
 ```
 
 ## Citations

--- a/packages/sdk/src/scopes/conversational/Conversation/index.ts
+++ b/packages/sdk/src/scopes/conversational/Conversation/index.ts
@@ -5,6 +5,8 @@ import {
   ExecuteBodyParams,
   FileUploadRes,
   SSEStreamEvents,
+  TaskStartEvent,
+  TaskStopEvent,
   ToolApprovalDecision,
 } from "../../../types";
 import {
@@ -575,6 +577,23 @@ export class Conversation extends EventEmitter<SSEStreamEvents> {
       this.connection.on("reasoning", (data) => {
         const chunk = JSON.parse(data);
         this.emit("reasoning", chunk.text);
+      });
+
+      // Task events are informational: a malformed frame must never reject the stream.
+      this.connection.on("task_start", (data) => {
+        try {
+          this.emit("task_start", JSON.parse(data) as TaskStartEvent);
+        } catch {
+          // Ignore unparseable task frames.
+        }
+      });
+
+      this.connection.on("task_stop", (data) => {
+        try {
+          this.emit("task_stop", JSON.parse(data) as TaskStopEvent);
+        } catch {
+          // Ignore unparseable task frames.
+        }
       });
 
       this.connection.on("stop", (data) => {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -215,6 +215,50 @@ export type AgentResult = {
 }
 
 /**
+ * Fields shared by both task lifecycle events emitted while the agent executes internal
+ * tasks such as skills.
+ */
+export type TaskEventBase = {
+  /** The event name, mirroring the SSE event: `task_start` or `task_stop`. */
+  type: string;
+  /** Human-readable description of the task, e.g. `Executing Skill: GetProductInfo`. */
+  task: string;
+  /**
+   * Identifier of the task being executed, e.g. `skills_GetProductInfo_execute`.
+   * Skill executions follow the `skills_<SkillCode>_execute` convention.
+   */
+  task_key: string;
+  start_time_utc?: string;
+  /** Details about the executed task. For skills, `skill.code` is the skill code. */
+  metadata?: {
+    skill?: { type?: string; code?: string };
+    [key: string]: any;
+  };
+  /** Additional fields the server may include are preserved. */
+  [key: string]: any;
+};
+
+/**
+ * Payload of the `task_start` event.
+ */
+export type TaskStartEvent = TaskEventBase & {
+  /** The arguments the task was invoked with. Shape depends on the task. */
+  input?: { [key: string]: any };
+};
+
+/**
+ * Payload of the `task_stop` event.
+ */
+export type TaskStopEvent = TaskEventBase & {
+  end_time_utc?: string;
+  /** Elapsed time as a .NET timespan string, e.g. `00:00:00.0002104`. */
+  duration?: string;
+  /** The task's result. Shape depends on the task. */
+  output?: any;
+  success?: boolean;
+};
+
+/**
  * Represents the events that can occur during a realtime session.
  * 
  * @remarks
@@ -229,6 +273,8 @@ export type AgentResult = {
  *   start: () => console.log('Stream started'),
  *   content: (chunk) => console.log('Received chunk:', chunk),
  *   error: (error) => console.error('Stream error:', error?.message),
+ *   task_start: (task) => console.log('Task started:', task.task_key),
+ *   task_stop: (task) => console.log('Task finished:', task.task_key),
  *   stop: (message) => console.log('Stream completed:', message)
  * };
  * 
@@ -279,6 +325,20 @@ export type SSEStreamEvents = {
    * @param message.action_results - Optional action results.
    */
   stop: (message: AgentResult) => void;
+
+  /**
+   * Event triggered when the agent starts executing an internal task, such as a skill.
+   * Only emitted on streamed executions.
+   * @param data - The task payload. `task_key` identifies the task.
+   */
+  task_start: (data: TaskStartEvent) => void;
+
+  /**
+   * Event triggered when the agent finishes executing an internal task, such as a skill.
+   * Only emitted on streamed executions.
+   * @param data - The task payload. `task_key` identifies the task.
+   */
+  task_stop: (data: TaskStopEvent) => void;
 };
 
 export type ExecuteBodyParams = Array<{


### PR DESCRIPTION
## Summary

Streamed conversational executions now expose the internal work an agent performs through the `task_start` / `task_stop` event pair. A *task* is any discrete step the agent runs on its way to an answer — today a skill execution, tomorrow whatever step types the platform adds. Consumers can use these events to show live progress in a UI, or to trace, time and log what the agent actually did.

The SDK forwards every task frame it receives without filtering, so new task types reach handlers as soon as the platform emits them. Each payload carries an index signature, so unknown server-added fields are preserved rather than stripped.

- `Conversation` subscribes to the `task_start` and `task_stop` SSE frames and re-emits them. Task events are informational, so an unparseable frame is ignored instead of rejecting the stream.
- New public types `TaskEventBase`, `TaskStartEvent` and `TaskStopEvent`; both events registered on `SSEStreamEvents`.
- Readme section documenting the events, both payload tables, and the `skills_<SkillCode>_execute` task key convention.
- `@serenity-star/sdk` bumped to `2.8.0`.

Only streamed executions (`streamMessage` / `stream`) emit these events; a non-streamed call still returns the final result only.

```ts
conversation
  .on("task_start", (task) => console.log("started", task.task, task.task_key))
  .on("task_stop", (task) =>
    console.log("finished", task.task_key, task.duration, task.success)
  )
  .on("content", (chunk) => process.stdout.write(chunk));

await conversation.streamMessage("What do we have in stock for vintage guitars?");
```

## Evidence

Sample `task_start` frame for a skill execution:

```json
{
  "type": "task_start",
  "task": "Executing Skill: GetProductInfo",
  "task_key": "skills_GetProductInfo_execute",
  "metadata": { "skill": { "type": "Prompt", "code": "GetProductInfo" } },
  "start_time_utc": "2026-08-24T10:22:54.1822224Z",
  "input": { "categoryName": "Music instruments from the 1960s" }
}
```

## Type of Change
- [ ] Bug fix
- [x] Feature
- [ ] Issue
- [ ] Refactor

## Checklists

### Security
- [x] Security impact of change has been considered
- [x] Backwards compatibility has been checked, if applicable (migrations, API contract)

Notes for the reviewer:

- **Data exposure.** `task_start.input` and `task_stop.output` carry the raw arguments and results of the executed task. In browser integrations these are now reachable by application code, so anything a skill receives or returns is visible to the client. This is data the server already sends over the same stream — the SDK only surfaces it — but consumers should avoid logging these payloads verbatim where skills handle personal or otherwise sensitive data. Worth a line in the readme if that concern is broader than this PR.
- **Backwards compatible.** Additive only: two new optional events plus new exported types. Existing handlers are untouched, and clients that do not subscribe behave exactly as before. Malformed task frames are swallowed, so the change cannot break an existing stream.

### General

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] Pull request linked to task tracker where applicable
- [x] Videos or Image evidence clearly show the developed functionality
- [x] Developer has auto reviewed the pulled request
- [x] Tags have been added if applicable (migration, log migration, etc)
- [x] Branch name follows convention ({version}/{sprint}/{workItemType}/{workItemNumber})
- [ ] Changes have been reviewed by at least one other contributor

---
*Serenity Star - Pull Request Template v.1 [2026-05-08]*
---
